### PR TITLE
[Superseded] Fix VDN bypass recursion across stacked runtime adapters

### DIFF
--- a/tests/test_bypass_reinject.py
+++ b/tests/test_bypass_reinject.py
@@ -1,10 +1,13 @@
-"""Regression test for the RecursionError after model reload (observed on the
-second generation when two adapter sets stack bypass hooks on the same modules).
+"""Regression tests for VDN bypass-hook reinjection and cross-provider teardown.
 
-Legacy behavior: injection sets are ejected in list order, which restores a
-stale hook as module.forward; the next load then captures that hook as its own
-"original" and the forward self-recurses. _install_injection's LIFO eject must
-keep load/unload cycles stable. Run from anywhere with the ComfyUI venv python.
+ComfyUI's ModelPatcher walks distinct injection keys in insertion order for both
+inject and eject. Plain BypassForwardHook teardown is only safe when wrappers are
+removed in strict global LIFO order, so two independent runtime-adapter providers
+can otherwise detach/resurrect stale forwards and eventually recurse forever.
+
+VDN's injection keeps its own adapter hooks in LIFO order, inserts VDN below an
+already-active standard Comfy bypass chain, and splices VDN out safely when another
+provider still wraps it. Run from anywhere with the ComfyUI venv python.
 """
 import sys
 import types
@@ -19,6 +22,7 @@ sys.path.insert(0, str(_COMFYUI_ROOT))
 sys.path.insert(0, str(_PACKAGE))
 
 import comfy.model_management
+import comfy.patcher_extension
 import comfy.weight_adapter
 from comfy.weight_adapter.bypass import BypassForwardHook
 from vdn_h3.apply import _FrugalLoRA, _install_injection
@@ -33,12 +37,24 @@ def _adapter():
 
 
 class _Patcher:
-    def __init__(self):
+    def __init__(self, model=None):
         self.injections = {}
-        self.model = types.SimpleNamespace()  # the shared inner model (clone-shared)
+        self.model = model if model is not None else types.SimpleNamespace()
 
     def set_injections(self, key, value):
         self.injections[key] = value
+
+    def inject_model(self):
+        # Mirrors ModelPatcher.inject_model's insertion-order traversal.
+        for injections in self.injections.values():
+            for injection in injections:
+                injection.inject(self)
+
+    def eject_model(self):
+        # Mirrors ModelPatcher.eject_model's insertion-order traversal.
+        for injections in self.injections.values():
+            for injection in injections:
+                injection.eject(self)
 
 
 def _fresh_module():
@@ -48,8 +64,8 @@ def _fresh_module():
 
 
 def _legacy_cycle_breaks():
-    """Documents the bug: forward-order eject leaves a stale hook in place, so
-    re-injecting makes the hook its own original forward."""
+    """Documents the original same-provider bug: forward-order eject leaves a
+    stale hook in place, so re-injecting makes the hook its own original forward."""
     mod, true_fwd = _fresh_module()
     hook_d = BypassForwardHook(mod, _adapter(), multiplier=1.0)
     hook_t = BypassForwardHook(mod, _adapter(), multiplier=1.0)
@@ -61,6 +77,20 @@ def _legacy_cycle_breaks():
     broken = hook_d.original_forward == hook_d._bypass_forward
     mod.forward = true_fwd              # restore for cleanliness
     return broken
+
+
+def _adapter_lora(hook, x):
+    up, down, _ = hook.adapter.weights
+    return torch.nn.functional.linear(
+        torch.nn.functional.linear(x, down), up)
+
+
+def _external_injection(hook):
+    """One independent provider using ComfyUI's ordinary bypass-hook lifetime."""
+    return comfy.patcher_extension.PatcherInjection(
+        inject=lambda _patcher: hook.inject(),
+        eject=lambda _patcher: hook.eject(),
+    )
 
 
 def test_lifo_cycles():
@@ -77,30 +107,102 @@ def test_lifo_cycles():
 
     for cycle in range(3):
         injection.inject(patcher)
-        assert mod.forward == hook_t._bypass_forward, f"cycle {cycle}: wrong outermost hook"
-        assert hook_t.original_forward == hook_d._bypass_forward, f"cycle {cycle}: T should wrap D"
-        assert hook_d.original_forward == true_fwd, f"cycle {cycle}: D should wrap the true forward"
+        assert mod.forward == hook_d._bypass_forward, f"cycle {cycle}: wrong outermost hook"
+        assert hook_d.original_forward == hook_t._bypass_forward, f"cycle {cycle}: D should wrap T"
+        assert hook_t.original_forward == true_fwd, f"cycle {cycle}: T should wrap the true forward"
         got = mod(x)
         assert torch.allclose(got, want, atol=1e-5), f"cycle {cycle}: wrong value"
         injection.eject(patcher)
         assert mod.forward == true_fwd, f"cycle {cycle}: true forward not restored"
         assert hook_d.original_forward is None and hook_t.original_forward is None
-    print("lifo cycles: PASS (3x inject/eject, values correct, true forward restored)")
 
 
-def _adapter_lora(hook, x):
-    up, down, _ = hook.adapter.weights
-    return torch.nn.functional.linear(
-        torch.nn.functional.linear(x, down), up)
+def _run_cross_provider_cycles(vdn_first):
+    mod, true_fwd = _fresh_module()
+    vdn_hook = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    external_hook = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    patcher = _Patcher()
+
+    if vdn_first:
+        _install_injection(patcher, [vdn_hook])
+        patcher.set_injections("external_runtime_lora", [_external_injection(external_hook)])
+    else:
+        patcher.set_injections("external_runtime_lora", [_external_injection(external_hook)])
+        _install_injection(patcher, [vdn_hook])
+
+    x = torch.randn(3, 8)
+    want = true_fwd(x) + _adapter_lora(vdn_hook, x) + _adapter_lora(external_hook, x)
+
+    for cycle in range(3):
+        patcher.inject_model()
+        # VDN deliberately stays inside the external Comfy bypass hook regardless
+        # of which injection key was inserted first.
+        assert mod.forward == external_hook._bypass_forward
+        assert external_hook.original_forward == vdn_hook._bypass_forward
+        assert vdn_hook.original_forward == true_fwd
+        assert torch.allclose(mod(x), want, atol=1e-5)
+
+        # This is the exact hazardous behavior in core today: providers are ejected
+        # in the same order they were injected, not global LIFO order.
+        patcher.eject_model()
+        assert mod.forward == true_fwd
+        assert vdn_hook.original_forward is None
+        assert external_hook.original_forward is None
+
+
+def test_cross_provider_forward_order_eject_vdn_first():
+    _run_cross_provider_cycles(vdn_first=True)
+
+
+def test_cross_provider_forward_order_eject_external_first():
+    _run_cross_provider_cycles(vdn_first=False)
+
+
+def test_live_vdn_replacement_under_external_hook():
+    """A fresh Apply-VDN result may replace hooks on the clone-shared inner model
+    while another runtime-adapter provider is still active. The old VDN hook must
+    be removed from the middle instead of detaching the external wrapper."""
+    mod, true_fwd = _fresh_module()
+    shared_owner = types.SimpleNamespace()
+    first = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    second = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    external = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+
+    patcher1 = _Patcher(shared_owner)
+    _install_injection(patcher1, [first])
+    inj1 = patcher1.injections["vdn_lora"][0]
+    inj1.inject(patcher1)
+    external.inject()
+
+    assert mod.forward == external._bypass_forward
+    assert external.original_forward == first._bypass_forward
+
+    patcher2 = _Patcher(shared_owner)
+    _install_injection(patcher2, [second])
+    inj2 = patcher2.injections["vdn_lora"][0]
+    inj2.inject(patcher2)
+
+    assert first.original_forward is None
+    assert mod.forward == external._bypass_forward
+    assert external.original_forward == second._bypass_forward
+    assert second.original_forward == true_fwd
+
+    x = torch.randn(2, 8)
+    want = true_fwd(x) + _adapter_lora(second, x) + _adapter_lora(external, x)
+    assert torch.allclose(mod(x), want, atol=1e-5)
+
+    inj2.eject(patcher2)
+    assert mod.forward == external._bypass_forward
+    assert external.original_forward == true_fwd
+    external.eject()
+    assert mod.forward == true_fwd
 
 
 if __name__ == "__main__":
     assert _legacy_cycle_breaks(), "legacy cycle did not reproduce the bug"
     print("legacy cycle: reproduces the self-hook bug as expected")
     test_lifo_cycles()
+    test_cross_provider_forward_order_eject_vdn_first()
+    test_cross_provider_forward_order_eject_external_first()
+    test_live_vdn_replacement_under_external_hook()
     print("ALL PASS")
-
-
-
-
-

--- a/vdn_h3/apply.py
+++ b/vdn_h3/apply.py
@@ -176,23 +176,119 @@ def _bypass(new_model, loaded, key_map, modules, sd_keys, strength, hooks):
     return n
 
 
-def _install_injection(new_model, hooks):
-    """All bypass hooks go through ONE PatcherInjection whose eject unwinds in
-    reverse. ComfyUI applies injection sets in list order on load and on unload;
-    with two stacked adapter sets (default + turbo), forward-order eject restores
-    a stale hook as module.forward, and the next load captures that hook as its
-    own "original" -- infinite self-recursion on the second run (observed as
-    RecursionError after a model reload). LIFO eject always restores the true
-    forward, so load/unload cycles are stable.
+def _same_bound_method(left, right):
+    """Identity check that is stable across repeated bound-method attribute reads."""
+    if left is right:
+        return True
+    left_self = getattr(left, "__self__", None)
+    right_self = getattr(right, "__self__", None)
+    left_func = getattr(left, "__func__", None)
+    right_func = getattr(right, "__func__", None)
+    return left_self is right_self and left_func is not None and left_func is right_func
 
-    STACK-PROOFING: every Apply-VDN run clones the patcher but every clone shares
-    ONE inner model, and ComfyUI ejects a clone's injections only when that clone
-    is UNLOADED -- on a big-VRAM card nothing unloads between runs, so re-running
-    with any widget changed (e.g. flipping lora_mode) would otherwise stack
-    ANOTHER full set of bypass hooks on the same modules: 2x, 3x the LoRA delta
-    per rerun, progressively grainy/fried output (merge is immune -- weight
-    patches go through backup/restore). The live hook set is tracked on the
-    shared inner model and ejected before a new set goes in."""
+
+def _bypass_hook_owner(forward):
+    """Return the Comfy bypass hook owning a bound forward, if there is one."""
+    hook_type = getattr(comfy.weight_adapter, "BypassForwardHook", None)
+    owner = getattr(forward, "__self__", None)
+    if isinstance(hook_type, type) and isinstance(owner, hook_type):
+        return owner
+    return None
+
+
+def _inject_hook_stack_safe(hook):
+    """Inject VDN below any already-active Comfy bypass-hook chain.
+
+    ModelPatcher injects and ejects distinct injection keys in the same order. If
+    two providers both replace ``module.forward``, ordinary forward-order teardown
+    can detach an outer hook or resurrect a stale inner one. Keeping VDN innermost
+    makes either provider order recoverable, while preserving the additive adapter
+    math.
+    """
+    if getattr(hook, "original_forward", None) is not None:
+        return
+
+    module = hook.module
+    previous_forward = module.forward
+    hook.inject()  # initializes adapter metadata/device placement as Comfy expects
+
+    outer = _bypass_hook_owner(previous_forward)
+    if outer is None:
+        return
+
+    current = outer
+    seen = set()
+    while True:
+        marker = id(current)
+        if marker in seen:
+            module.forward = previous_forward
+            hook.original_forward = None
+            raise RuntimeError("VDN found a cyclic Comfy bypass-forward chain")
+        seen.add(marker)
+
+        inner_forward = getattr(current, "original_forward", None)
+        inner = _bypass_hook_owner(inner_forward)
+        if inner is None:
+            break
+        current = inner
+
+    # hook.inject() temporarily made VDN outermost. Restore the pre-existing
+    # chain, then splice VDN immediately above its true/base forward instead.
+    module.forward = previous_forward
+    hook.original_forward = inner_forward
+    current.original_forward = hook._bypass_forward
+
+
+def _eject_hook_stack_safe(hook):
+    """Remove a VDN hook even when another Comfy bypass hook currently wraps it."""
+    original_forward = getattr(hook, "original_forward", None)
+    if original_forward is None:
+        return
+
+    module = hook.module
+    target = hook._bypass_forward
+    current_forward = module.forward
+
+    if _same_bound_method(current_forward, target):
+        module.forward = original_forward
+        hook.original_forward = None
+        return
+
+    current = _bypass_hook_owner(current_forward)
+    seen = set()
+    while current is not None:
+        marker = id(current)
+        if marker in seen:
+            raise RuntimeError("VDN found a cyclic Comfy bypass-forward chain during eject")
+        seen.add(marker)
+
+        inner_forward = getattr(current, "original_forward", None)
+        if _same_bound_method(inner_forward, target):
+            current.original_forward = original_forward
+            hook.original_forward = None
+            return
+        current = _bypass_hook_owner(inner_forward)
+
+    # Another provider may already have detached this hook by restoring an older
+    # forward. Do not clobber the currently valid chain by resurrecting our stale
+    # original; just mark this VDN hook inactive.
+    hook.original_forward = None
+
+
+def _install_injection(new_model, hooks):
+    """Install VDN bypass hooks with clone- and cross-provider-safe lifetime rules.
+
+    All VDN hooks live inside one PatcherInjection and are removed in reverse VDN
+    order. In addition, VDN is spliced below any already-active standard Comfy
+    ``BypassForwardHook`` chain and can remove itself from the middle of such a
+    chain. This matters because ModelPatcher currently walks distinct injection
+    keys in insertion order for both inject and eject; another runtime-LoRA
+    provider can therefore still be active when VDN tears down (or vice versa).
+
+    Every Apply-VDN run clones the patcher but clones share one inner model. The
+    live VDN hook set is tracked on that shared model and removed before a fresh
+    VDN set is installed, preventing reruns from accumulating adapter deltas.
+    """
     if not hooks:
         return
     owner = new_model.model      # shared by every clone of this model
@@ -201,14 +297,19 @@ def _install_injection(new_model, hooks):
         old = getattr(owner, "_vdn_live_hooks", None)
         if old:
             for hook in reversed(old):
-                hook.eject()
-        for hook in hooks:
-            hook.inject()
+                _eject_hook_stack_safe(hook)
+        try:
+            for hook in hooks:
+                _inject_hook_stack_safe(hook)
+        except Exception:
+            for hook in reversed(hooks):
+                _eject_hook_stack_safe(hook)
+            raise
         owner._vdn_live_hooks = hooks
 
     def eject_all(model_patcher):
         for hook in reversed(hooks):
-            hook.eject()
+            _eject_hook_stack_safe(hook)
         if getattr(owner, "_vdn_live_hooks", None) is hooks:
             owner._vdn_live_hooks = None
 
@@ -321,4 +422,3 @@ def _inject_adaln_egrid(new_model, dm, lora, adaln_modules, strength):
         new_model.add_object_patch(
             key + ".forward",
             _make_adaln_forward(new_model.get_model_object(key), a, b, shared, tt, e))
-


### PR DESCRIPTION
> **Superseded by #2 / v1.5.0.** This PR fixed the old forward-hook bypass architecture by making its hook-chain teardown stack-safe. PR #2 took the stronger approach instead: it removed VDN's forward-hook bypass implementation entirely and moved runtime LoRA handling onto Comfy-managed weight/bias wrapper lifecycle. That eliminates the stale/cyclic `module.forward` chain at the architectural boundary rather than maintaining compatibility inside the old hook stack. The replacement is merged on `main` as `1fc9d0d979683e3410587fac17358d3dd583e551` and released as v1.5.0. This PR is retained only as historical context for the original failure analysis and regression direction.

## Problem

A Continuum run with VDN bypass adapters plus another runtime-bypass LoRA provider can fail on the next chunk/model lifecycle with:

```text
BypassForwardHook._bypass_forward
  -> vdn_h3.apply._FrugalLoRA.bypass_forward
  -> org_forward(...)
  -> BypassForwardHook._bypass_forward
  -> ...
RecursionError: maximum recursion depth exceeded
```

The failure happens before the H3 transformer actually starts the chunk; the forward chain itself has become cyclic/stale.

## Root cause

VDN already grouped its own bypass hooks into one `PatcherInjection` and ejected those hooks in reverse order. That fixes the *within-VDN* default/turbo stacking case, but it does not make VDN safe against a second independent `PatcherInjection` provider.

Current ComfyUI `ModelPatcher` walks distinct injection keys in insertion order for both `inject_model()` and `eject_model()`. `BypassForwardHook` itself restores `module.forward = original_forward` on eject. With two providers on the same module, forward-order teardown can therefore detach an outer wrapper or later resurrect a stale inner wrapper. Repeated clone/load/unload cycles can turn that stale chain into the observed recursive `_FrugalLoRA` loop.

## Historical fix proposed here

- insert VDN hooks **inside/under** any already-active standard ComfyUI `BypassForwardHook` chain instead of blindly becoming the new outermost wrapper;
- remove VDN hooks by **splicing them out of the live chain** when another runtime provider still wraps them;
- if another provider already detached a VDN hook, mark it inactive without overwriting the currently valid `module.forward` with a stale original;
- use the same stack-safe removal when replacing `_vdn_live_hooks` on the clone-shared inner model;
- roll back partially injected VDN hooks on injection failure;
- fail explicitly if an already-corrupted cyclic Comfy bypass chain is detected.

The adapter math is unchanged. `merge` mode is untouched.

## Regression coverage in this superseded branch

`tests/test_bypass_reinject.py` covers:

- repeated two-VDN-hook inject/eject cycles;
- VDN injection key first, external runtime-bypass key second, while reproducing ComfyUI's forward-order teardown;
- external runtime-bypass key first, VDN second;
- repeated cycles in both cross-provider orders with value checks;
- replacing the live VDN hook set on a clone-shared model while an external bypass hook remains active.

These tests document the lifecycle invariant that was missing from the earlier LIFO-only regression.

## Why this was not merged

The final v1.5.0 implementation in #2 no longer makes VDN responsible for traversing, replacing, restoring, or chaining LoRA-target `module.forward` methods. Because the problematic hook architecture was removed, merging this hook-splicing patch would reintroduce maintenance for a code path that no longer exists.

Historical branch topology:

- base at creation: `main` @ `183f33d8a7b3c6322d83be95ae369251a63b3198`
- head: `fix/bypass-injection-stack-lifetime` @ `c53073f313cfd961f13d56eee0bfc2028555feb4`
