### PR TITLE
Release v1.5.1 stacked runtime-bypass hotfix

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -1,22 +1,25 @@
 # Benchmarks — ComfyUI-VDN-H3
 
-This file preserves historical measurements from earlier releases and defines the measurement contract for the current correctness/lifecycle refactor. **Historical numbers are not performance validation of the current branch.**
+This file preserves historical measurements and defines the measurement contract for the current runtime. **Historical numbers are not performance validation of v1.5.1.**
 
-The current implementation differs materially from the runs below:
+## Current v1.5.1 execution differences
 
-- the old forward-hook LoRA bypass is replaced by a Comfy-owned runtime `weight_function` path;
-- VDN no longer traverses, splices or restores mutable `module.forward` LoRA chains;
-- the old private GPU branch cache is replaced by either bounded streaming or a Comfy-managed additional `ModelPatcher`;
-- safetensors mappings are bounded to load operations rather than retained process-global handles;
-- curve/pruned AdaLN adapters are projected through the exact pruning affine (`adaln_basis` + `adaln_mean`) onto the native curve coordinates, including their constant bias term, rather than dropping weights or running a reconstructed dense timestep MLP;
-- selected upstream v1.4 performance ideas are adapted under state-owned lifecycle rules: VRAM-aware branch selection, native INT8 ConvRot streaming under pressure, execution-leased retained scratch, and one-block streaming prefetch;
-- `auto` placement reserves still-unloaded base-model bytes before deciding that VDN may consume free VRAM.
+Compared with the older measurements below:
 
-New matched GPU measurements are therefore required before making speed, VRAM or output-parity claims for this branch.
+- `lora_mode=bypass` uses stack-safe activation-side Comfy `BypassForwardHook` adapters for ordinary LoRA targets;
+- the v1.5.0 `add_weight_wrapper()` / `weight_function` adapter path is no longer active;
+- VDN can coexist with another ordinary Comfy runtime-bypass provider on the same module by inserting underneath the existing chain and splicing itself out safely;
+- fused INT8 `mlp.fc2` targets that do not call `module.forward` remain ordinary Comfy weight patches;
+- full-width curve/pruned AdaLN adapters are projected through the exact pruning affine and applied as native curve weight + bias patches;
+- the old private GPU branch cache is replaced by bounded streaming or a Comfy-managed additional `ModelPatcher`;
+- selected upstream v1.4 performance work is retained under state-owned lifecycle rules: VRAM-aware branch selection, native INT8 ConvRot streaming under pressure, execution-leased retained scratch, and one-block streaming prefetch;
+- `auto` placement reserves still-unloaded base-model bytes before assigning VDN residency.
+
+New matched GPU measurements are required before assigning speed or VRAM numbers to v1.5.1.
 
 ## Historical RTX 5090 measurements
 
-These measurements predate the current refactor.
+These measurements predate the v1.5/v1.5.1 lifecycle work.
 
 ### Rig
 
@@ -32,8 +35,6 @@ These measurements predate the current refactor.
 - CFG: 1
 - generation: t2v + audio
 
-The original runs used the then-current implementation, including the old `BypassForwardHook`-based `lora_mode=bypass` and the old private `cache_gpu` branch path. Those names may still appear in serialized workflows, but the current implementations are different. Historical bypass/cache numbers therefore must not be attributed to the new runtime or managed-residency paths.
-
 ### 1280x736, 145 frames
 
 Approximate layout: F=37, S=920, total packed sequence about 34,487 tokens.
@@ -43,85 +44,46 @@ Approximate layout: F=37, S=920, total packed sequence about 34,487 tokens.
 | grouped | 16.92–16.95 | ~2:15 | cold + warm runs |
 | flex | 17.10 | ~2:17 | warm run after compilation |
 
-On that workload the grouped implementation was effectively tied with FlexAttention. That is a hardware/workload-specific historical observation, not a current-branch result.
+On that workload grouped was effectively tied with FlexAttention. This is a hardware/workload-specific historical observation.
 
 ### 512x320, 56 frames
 
 An 8-step end-to-end smoke render with audio completed successfully during earlier correctness bring-up.
 
-## Historical v1.2/v1.3 validation
-
-Earlier release validation included:
-
-- eager vs `fast_kernels` comparisons;
-- merge vs the **old forward-hook bypass** implementation;
-- full and pruned MiniMax-H3 bases;
-- fixed-seed 512x320 / 56-frame 8-step renders;
-- INT8 ConvRot experiments.
-
-Those runs were useful in finding lifecycle and numerical problems in the old bypass implementation. In particular, the historical Stage-DMD bypass path showed visible degradation relative to merge. The current `lora_mode=bypass` does not execute adapters through that mechanism, so those results neither validate nor condemn the new runtime mode.
-
-## Upstream v1.4 performance work
-
-Saganaki22's upstream v1.4 added meaningful performance work around branch-file selection, retained buffers, streaming prefetch and attention/runtime allocation behavior. This branch incorporates the useful ideas but **does not copy its ownership model verbatim**.
-
-The current adaptation intentionally differs where correctness/lifecycle guarantees require it:
-
-- no persistent `safe_open`/mmap handle cache;
-- no process-global branch-weight GPU cache;
-- native INT8 ConvRot is selected under memory pressure but remains streamed rather than being hidden in an unmanaged resident cache;
-- ordinary BF16 residency is represented as a real Comfy additional `ModelPatcher`;
-- retained scan/window/activation scratch is owned by one `VDNState` and leased per diffusion-model execution;
-- nested/concurrent executions that cannot acquire the retained pool use isolated transient scratch;
-- one-block prefetch uses one bounded process worker that owns no model tensors/cache; each VDN state owns at most one cancellable future/result;
-- prefetched results are keyed by `(block, device, dtype)` to prevent stale placement reuse;
-- `auto` free-VRAM calculations subtract still-unloaded bytes of the supplied base `MODEL` before branch/scratch policy decisions.
-
-Upstream v1.4 benchmark numbers therefore remain useful motivation/reference data, not measurements of this implementation.
-
-## Current adapter modes that need matched measurement
+## Adapter modes
 
 ### `lora_mode=merge`
 
-Normal Comfy `ModelPatcher.add_patches()` application. This is the reference/eager path for output comparison. Quantized bases can incur a temporary dequantize -> patch -> requantize VRAM spike during eager materialization.
-
-On a curve/pruned base, a released full-width AdaLN LoRA is first transformed through the base's pruning affine. The projected low-rank weight update and its constant F32 bias term are then registered as ordinary Comfy patches.
+Normal Comfy `ModelPatcher.add_patches()` application. This is the conservative reference path for output comparison. Quantized bases can incur a temporary dequantize -> patch -> requantize materialization cost during load.
 
 ### `lora_mode=bypass`
 
-The current low-VRAM runtime path uses Comfy `add_weight_wrapper()` / `weight_function` ownership. It does not modify `module.forward`, does not create VDN LoRA injections, and leaves the resident base parameter unmerged. Low-rank Stage-B/Turbo terms are applied to the floating compute weight Comfy produces for the current invocation; the implementation avoids constructing a second persistent full-size patched model weight.
+Ordinary adapter targets keep the resident base parameter untouched and add their low-rank activation delta through Comfy's bypass-hook mechanism. VDN's injection layer is specifically regression-tested with an independent external runtime-bypass provider in both provider insertion orders and across repeated load/unload cycles.
 
-For curve/pruned AdaLN targets, the projected A/B factors and F32 constant bias offsets live in the same Comfy-managed additional model. Separate weight and bias wrappers apply them to the native small AdaLN projection. There is no dense timestep MLP and no AdaLN `forward` object patch in this path.
+This path preserves the native base forward for quantized/custom layers instead of installing the v1.5.0 `weight_function` wrapper. That distinction matters because a Comfy weight function on quantized H3 can force a copied/dequantized compute-weight path.
 
-On INT8/custom-weight layers, a runtime weight wrapper can force a dequantized compute fallback for the patched invocation instead of the fused quantized kernel. The tradeoff is therefore lower patched-weight residency/load pressure versus potentially higher per-call compute cost. This must be measured rather than inferred.
+The production reason for the v1.5.1 hotfix was a hard CUDA illegal-address abort in the stacked INT8 ConvRot H3 + VDN bypass + external runtime-DoRA + `cudaMallocAsync` workflow after v1.5.0 introduced runtime weight wrappers. CUDA failure reporting is asynchronous, so that trace does not prove which kernel originally faulted, but the v1.5.0 wrapper path was the new regression boundary and is no longer used.
 
 ## Curve/pruned AdaLN projection
 
-For the supported pruned MiniMax-H3 lineage, the dense AdaLN input is represented by the pruning affine
+For supported pruned MiniMax-H3 bases:
 
 ```text
 dense(t) ≈ mean + curve(t) @ basis
 ```
 
-A released full-width LoRA `B @ A` is therefore converted once as
+A released full-width LoRA `B @ A` is converted once as:
 
 ```text
 A_pruned   = A @ basis.T
 bias_delta = B @ (A @ mean)
 ```
 
-The projection math is performed once in float64. Projected A and the constant bias term are stored as F32; B retains its checkpoint storage dtype until Comfy selects the invocation compute dtype. This adds no new model approximation beyond the pruned base's existing affine representation. The constant term is required; dropping it would not reproduce the affine-projected adapter.
+The constant term is required. v1.5.1 registers the projected native curve weight and bias terms as ordinary Comfy patches in both adapter modes; there is no reconstructed dense timestep MLP and no runtime weight wrapper for these terms.
 
-The affine resolver accepts only the exact pruning basis/mean corresponding to the loaded curve table:
+The affine resolver accepts only the exact pruning basis/mean corresponding to the loaded curve table. A mismatched or unverifiable affine fails closed.
 
-- stage-local `adaln_affine.safetensors` is the explicit companion path;
-- the selected diffusion checkpoint and sibling safetensors are searched first;
-- installed `models/diffusion_models` candidates are also searched;
-- installed candidates must carry the matching curve table or a matching table identity; a different or unverified basis fails closed.
-
-The repaired BF16 pruned source checkpoint can retain `adaln_basis` and `adaln_mean`; its INT8 derivatives may intentionally omit those inference-unused auxiliaries. Keeping the matching BF16 sibling installed is sufficient—the resolver reads only the tiny affine tensors/table from it. Otherwise `tools/extract_h3_adaln_affine.py` writes an approximately 97 KB sidecar.
-
-## Current branch residency modes
+## Branch residency
 
 `lora_mode` is independent of VDN linear-branch residency.
 
@@ -130,8 +92,7 @@ The repaired BF16 pruned source checkpoint can retain `adaln_basis` and `adaln_m
 - starts from Comfy's current free-memory reading;
 - subtracts bytes of the supplied base `MODEL` that are not resident yet;
 - chooses ordinary BF16 `resident` only when the remaining budget satisfies the branch-size/headroom rule;
-- otherwise selects `stream` and prefers the native INT8 ConvRot branch file when available;
-- quantized branch weights are not silently promoted into an unmanaged resident cache.
+- otherwise selects `stream` and prefers the native INT8 ConvRot branch file when available.
 
 ### `branch_weights=stream`
 
@@ -145,22 +106,11 @@ The repaired BF16 pruned source checkpoint can retain `adaln_basis` and `adaln_m
 - uses Comfy load/offload/device lifecycle;
 - quantized branch files fail closed for resident mode rather than silently dequantizing them.
 
-A minimum-memory configuration can combine `lora_mode=bypass` with `branch_weights=stream` and `retain_buffers=off`.
-
 ## Retained runtime buffers
 
-`retain_buffers=auto|on|off` controls VDN scratch, not model weights.
+`retain_buffers=auto|on|off` controls VDN scratch, not model weights. Retained mode can reuse bounded recurrence, grouped-window, activation-copy and prefetch scratch owned by one `VDNState`. One execution leases the pool; nested/concurrent execution falls back to isolated transient storage.
 
-Retained mode can reuse bounded storage for:
-
-- forward/reverse recurrence banks;
-- grouped-window plan/gather scratch;
-- video/text raw Q/K/V copies;
-- streaming lookahead state.
-
-The pool is owned by the `VDNState`, not by process-global module dictionaries. One execution leases the retained pool; nested/concurrent executions fall back to transient storage so the same CUDA buffers are not raced. Cancellation clears the state-owned persistent scratch.
-
-`auto` uses the effective free-VRAM budget (after unloaded base reservation) and the selected branch-file size. It is a heuristic that still requires real GPU validation.
+Under `cudaMallocAsync`, explicit `record_stream` bookkeeping is skipped because the allocator is already stream ordered.
 
 ## Current CI validation
 
@@ -168,65 +118,15 @@ CI validates implementation contracts rather than performance:
 
 - pinned ComfyUI: `6c53f8c9a06d95f3d847009ceaae55c624169247`;
 - official OpenVDN oracle: `b8cb28fbfca0266d1c7742a9f25ab8b58191de97`;
-- direct reduced-dimension source-to-source oracle comparisons, including the official `HybridAttention` class;
-- adapter conversion including hybrid/dense/token-refiner naming and fused variable-rank/scaled QKV patches;
-- curve/pruned affine AdaLN projection tests, including the constant bias term, merge/runtime lifecycle, file replacement invalidation, wrong-table rejection and the production 51-target shape;
-- direct KJ-loader-style selected-INT8 + matching-BF16-sibling affine discovery regression;
-- ModelSpec and checkpoint corruption/invalidation tests;
+- source-to-source numerical oracle comparisons;
+- adapter conversion and checkpoint/model-spec validation;
+- curve/pruned affine projection including the constant bias term;
 - merge-path custom/quantized weight lifecycle tests;
-- runtime-low-VRAM wrapper tests showing no forward hooks, no resident base-weight mutation and no adapter accumulation;
-- retained-vs-transient VDN branch/window numerical identity tests;
-- runtime resource lease/isolation tests;
-- prefetch placement identity tests;
-- base-residency-aware `auto` VRAM budget tests;
-- repeated clone/load/unload and pseudo-Continuum conditioning/forward cycles;
-- current Comfy `master` import/node-registration smoke.
+- stack-safe bypass lifecycle tests across independent providers and repeated cycles;
+- explicit assertions that active bypass installs no `weight_wrapper_patches`;
+- retained-vs-transient branch/window numerical identity;
+- resource lease/isolation and prefetch placement tests;
+- current ComfyUI-main import/registration smoke;
+- legacy `ApplyVDNH3Advanced` positional-workflow migration.
 
-The suite includes the KJ sibling-affine regression; see the pinned CI run for the current test count. Synthetic CPU tests intentionally do not stand in for real GPU VRAM, kernel selection, output quality or end-to-end performance.
-
-## Production GPU validation status
-
-The target RTX Pro 6000 / INT8-ConvRot workflow has already validated two important pre-sampling gates:
-
-- `branch_weights=auto` correctly selected the quantized VDN branch and kept it streamed under the managed-lifecycle policy;
-- released Stage-B/Turbo attention names are now converted to current Comfy fused `qkv_proj`/`out_proj` targets instead of failing on unfused names.
-
-The next production attempt then reached the 51 full-width Turbo AdaLN targets and stopped before sampling because the older implementation required a dense time embedder. That requirement is what the new pruning-native affine projection replaces. The same workflow must now be rerun before any end-to-end performance or quality conclusion is drawn.
-
-## Required real GPU matrix
-
-Before claiming current-branch performance, output parity, or VRAM savings, collect matched fixed-seed runs for at least:
-
-- BF16 MiniMax-H3 base;
-- pruned/curve base with verified affine AdaLN projection;
-- INT8 ConvRot base;
-- `stage-dmd-step-250` with Turbo/DMD adapter at 8 steps;
-- `stage-b-step-2000` without Turbo at the intended longer schedule;
-- `lora_mode=merge` vs the **new** `lora_mode=bypass`;
-- non-1.0 adapter strengths;
-- `branch_weights=auto`, `stream`, and supported `resident`;
-- `retain_buffers=auto`, `on`, and `off` where practical;
-- grouped vs FlexAttention;
-- repeated renders with the base kept resident;
-- cancel then rerun without restarting ComfyUI;
-- Continuum multi-chunk execution and reruns without restarting ComfyUI;
-- ordinary LoRA composition and Dynamic DoRA/LoRA Loader with its Runtime Bypass OFF;
-- Spectrum, DiffAid and Untwist RoPE where those are part of the target workflow.
-
-For every matched run record:
-
-- exact base/VDN checkpoint hashes;
-- exact node commit and Comfy commit;
-- resolution, frame count, sampler/scheduler, steps and seed;
-- wall time and sampler time;
-- peak VRAM / minimum free VRAM;
-- model-load/adapter-materialization peak separately from steady-state sampling;
-- selected branch file and resolved `auto` policy;
-- retained/transient buffer policy;
-- branch-transfer/prefetch time where measurable;
-- attention time;
-- compile cost separately from steady state when `torch.compile` is enabled;
-- whether patched INT8 layers remained on their fused kernel or used the dequantized runtime fallback;
-- fixed-seed visual/audio comparison against `merge`.
-
-The critical lifecycle gate is a real Continuum run beyond chunk 1: Apply must resolve/project all 51 Turbo AdaLN targets, chunk 2+ must reach actual H3 transformer evaluations, repeated runs must not accumulate adapters, and no VDN LoRA `module.forward` chain should exist.
+Real decoded-media output and GPU timing remain separate release evidence, not something inferred from CPU CI.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A ComfyUI port of the released [OpenVDN VDN-H3](https://github.com/OpenVDN/vdn-minimax-h3) hybrid-attention architecture for ComfyUI's native MiniMax-H3 model.
 
-This xmarre fork keeps the released VDN math/checkpoint contract while tightening ComfyUI lifecycle ownership, supporting current pruned/INT8 H3 bases, and adding the external mixed-grid sequence contract used by [MiniMax-H3 Flow-Aligned Regenerate](https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate).
+This xmarre fork keeps the released VDN checkpoint/math contract while adding current pruned/INT8 H3 support, stricter Comfy lifecycle handling, and the external mixed-grid sequence contract used by [MiniMax-H3 Flow-Aligned Regenerate](https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate).
 
 > The VDN model weights are separate from this repository and retain their upstream license. See [NOTICE](NOTICE) for implementation provenance and attribution.
 
@@ -32,14 +32,12 @@ Official stages include:
 
 ### Apply VDN-H3
 
-The normal node exposes the released checkpoint with the main runtime controls:
-
 | Input | Meaning |
 |---|---|
 | `vdn_checkpoint` | Stage directory under `models/vdn/` |
 | `apply_turbo_adapter` | Apply the released Turbo/DMD adapter when the stage provides it |
 | `strength` | Adapter strength; `1.0` is the released setting |
-| `lora_mode` | `merge` or Comfy-managed runtime `bypass` |
+| `lora_mode` | `merge` or stack-safe runtime `bypass` |
 | `branch_weights` | `auto`, `stream`, or `resident` |
 | `retain_buffers` | `auto`, `on`, or `off` |
 | `attention_backend` | `grouped` or opt-in `flex` |
@@ -55,22 +53,31 @@ Adds independent Stage-B/Turbo strengths, optional compiled helpers, and explici
 
 ### `lora_mode=merge`
 
-Uses ordinary Comfy `ModelPatcher.add_patches()` ownership. This remains the conservative reference path for matched output validation.
+Uses ordinary Comfy `ModelPatcher.add_patches()` weight ownership. This remains the conservative reference path for matched output validation.
 
 ### `lora_mode=bypass`
 
-The workflow-facing name is retained, but the old forward-hook bypass implementation is gone.
+v1.5.1 uses Comfy's activation-side `BypassForwardHook` mechanism for ordinary VDN LoRA targets, with an additional VDN lifecycle layer that makes independently owned runtime adapter providers safe to stack.
 
-The current runtime path:
+The important properties are:
 
-- uses Comfy's public weight/bias wrapper lifecycle;
-- does not replace or traverse LoRA target `module.forward` methods;
-- leaves resident base parameters unmerged;
-- stores LoRA factors as Comfy-managed additional-model state;
-- bounds low-rank delta temporaries;
-- keeps separate Apply executions distinct while normal model clones remain equivalent.
+- VDN does not assume it is the only runtime-bypass provider on a module;
+- if another Comfy bypass hook is already active, VDN inserts underneath it rather than blindly becoming the outermost owner;
+- teardown can splice VDN out of the middle of the live chain without restoring a stale `module.forward`;
+- the same logic works whether VDN or the external provider was registered first;
+- rerunning Apply VDN replaces the previous live VDN hook set on the clone-shared inner model instead of accumulating another adapter delta;
+- pre-existing cyclic bypass chains fail closed;
+- fused INT8 `mlp.fc2` targets that do not call `module.forward` stay on normal Comfy weight patches.
 
-On fused/quantized H3 layers, a runtime weight wrapper can make Comfy use a dequantized compute path for that invocation. Treat that as a memory/compute tradeoff rather than a universal speed claim.
+### Why v1.5.1 changed bypass again
+
+v1.5.0 temporarily implemented bypass with `ModelPatcher.add_weight_wrapper()` / `weight_function` and a managed A/B-factor model. On quantized H3, a weight function changes execution onto Comfy's copied/dequantized compute-weight path.
+
+A production RTX PRO 6000 run combining the INT8 ConvRot H3 base, VDN bypass, a second runtime-bypass DoRA/LoRA provider, `cudaMallocAsync`, Flow Mixed-Grid, Continuum and Spectrum/SA-PECE hard-aborted on the first actual H3 evaluation with a CUDA illegal memory access. The fatal stack was inside the external Comfy bypass-LoRA chain. Because CUDA reporting is asynchronous, the stack does not by itself identify the exact originating kernel, but the v1.5.0 weight-wrapper execution path was the new regression boundary.
+
+The older stack-safe activation-hook implementation had already been validated with the same cross-provider lifecycle, so v1.5.1 restores that proven execution architecture rather than trying to patch around the quantized weight-wrapper interaction.
+
+The v1.5.0 wrapper path is **not** installed by `lora_mode=bypass` in v1.5.1.
 
 ## Pruned / curve MiniMax-H3 bases
 
@@ -87,7 +94,9 @@ A_pruned   = A @ basis.T
 bias_delta = B @ (A @ mean)
 ```
 
-Both terms are required. The projection is fail-closed: VDN must resolve the matching `adaln_basis` + `adaln_mean` pair for the loaded curve table and will not silently guess or drop unsupported AdaLN updates.
+Both terms are required. VDN must resolve the matching `adaln_basis` + `adaln_mean` pair and fails closed rather than guessing or dropping incompatible AdaLN updates.
+
+In v1.5.1, the projected curve weight and constant bias terms use ordinary Comfy weight/bias patches in both adapter modes. They do not use the activation-side VDN hooks and do not use the superseded v1.5.0 weight-wrapper path.
 
 If a matching BF16 source checkpoint remains beside an INT8 derivative, VDN can read only the small affine tensors from it. Otherwise use:
 
@@ -103,35 +112,33 @@ python tools/extract_h3_adaln_affine.py \
 
 - `auto` reserves still-unloaded H3 base-model bytes before deciding what VDN may keep resident. It uses resident BF16 branch weights when headroom is sufficient; otherwise it streams and prefers the native INT8 ConvRot branch when available.
 - `stream` resolves one block at a time and can use one-block lookahead when retained buffers are enabled.
-- `resident` registers ordinary BF16 branch weights as a real Comfy-managed additional `ModelPatcher`.
+- `resident` registers ordinary BF16 branch weights as a Comfy-managed additional `ModelPatcher`.
 
 `retain_buffers=on` reuses execution-owned scan/window/activation scratch. The retained pool belongs to one VDN state and is leased for one diffusion-model execution; nested/concurrent runs that cannot acquire it use isolated transient scratch.
 
-Under `cudaMallocAsync`, explicit `record_stream` bookkeeping is skipped because the allocator is stream ordered already. This incorporates upstream v1.4.3's torch-warning fix in this fork's state-owned prefetch implementation.
+Under `cudaMallocAsync`, explicit `record_stream` bookkeeping is skipped because the allocator is already stream ordered. This incorporates upstream v1.4.3's torch-warning fix in this fork's state-owned prefetch implementation.
 
 ## Flow-Aligned Regenerate interoperability
 
-VDN supports two external-sequence contracts used by MiniMax-H3 Flow-Aligned Regenerate:
+VDN supports the external-sequence contracts used by MiniMax-H3 Flow-Aligned Regenerate:
 
 - API 1 target-sparse compatibility;
 - API 2 `mixed_grid_low_suffix` for a target-grid protected prefix plus a genuine low-grid generated suffix.
 
-During an external mixed sequence VDN keeps the learned dense softmax gate active and disables only geometry-dependent local-window/linear-complement work that cannot be interpreted on the mixed lattice. The fresh target-grid stage returns to normal VDN execution automatically.
+During an API-2 mixed sequence, VDN keeps the learned dense softmax gate active and disables only geometry-dependent local-window/linear-complement work that cannot be interpreted on the mixed lattice. The fresh target-grid stage returns to normal VDN execution automatically.
 
 See [docs/MIXED_SEQUENCE_API.md](docs/MIXED_SEQUENCE_API.md) for the exact fail-closed contract.
 
 ## Legacy Advanced-node workflow compatibility
 
-v1.5.0 fixes old `ApplyVDNH3Advanced` workflows that were saved before ComfyUI serialized widget values by name.
+The original Advanced node had 14 positional widgets. v1.5 added `retain_buffers` and `architecture_mode`, which would shift values in workflows saved before ComfyUI emitted `widgets_values_named`.
 
-The original Advanced node had 14 positional widgets. PR #2 added `retain_buffers` and `architecture_mode`, which shifted old arrays and could restore values such as `"both"` into `window_radius`.
-
-The included frontend migration now:
+The included frontend migration:
 
 - publishes the original 14 names through `fallbackWidgetsValuesNames`;
 - restores old positional values by name;
 - inserts `retain_buffers="auto"`;
-- inserts `architecture_mode="override"` for old workflows, preserving their historical behavior because those architecture fields used to apply unconditionally;
+- inserts `architecture_mode="override"` for old workflows because those architecture fields historically applied unconditionally;
 - preserves the short-lived 16-value positional layout without changing its semantics;
 - leaves workflows that already contain `widgets_values_named` untouched.
 
@@ -140,22 +147,24 @@ Newly created nodes still default to `architecture_mode="checkpoint"`.
 ## Compatibility notes
 
 - `grouped` is the portable attention backend and remains the default. `flex` is opt-in and falls back to grouped if unavailable.
-- VDN owns the H3 attention object patch. Another extension that tries to own the same `diffusion_model.blocks.*.attn.forward` target is incompatible and is rejected rather than ambiguously stacked.
-- Ordinary model weight patches/LoRAs remain under Comfy's normal weight lifecycle.
+- VDN owns the H3 attention object patch. Another extension that tries to own the same `diffusion_model.blocks.*.attn.forward` target is rejected rather than ambiguously stacked.
+- Runtime LoRA/DoRA providers using Comfy's ordinary `BypassForwardHook` mechanism may coexist with VDN bypass; the cross-provider chain is regression-tested in both insertion orders.
 - The AIMDO malloc-graph compatibility guard is scoped only around VDN diffusion-model execution and restores the user's compiler setting afterward.
-- Historical benchmark numbers in [Benchmarks.md](Benchmarks.md) predate major lifecycle changes and are not assigned to the current runtime without matched measurement.
+- Historical benchmark numbers in [Benchmarks.md](Benchmarks.md) predate the current lifecycle work and are not assigned to this runtime without matched measurement.
 
 ## Validation
 
-v1.5.0 is gated by:
+v1.5.1 adds explicit regression coverage for:
 
-- pinned ComfyUI + official OpenVDN numerical/oracle tests;
-- current ComfyUI-main import/registration smoke;
-- adapter, pruning-affine, lifecycle, external-sequence, retained-buffer and compiler-guard tests;
-- a dedicated `cudaMallocAsync` allocator regression;
-- a frontend regression using an actual old 14-value Advanced-node `widgets_values` array.
+- repeated VDN hook injection/ejection;
+- VDN-first and external-provider-first stacked bypass providers;
+- live VDN replacement while an external runtime provider stays active;
+- cyclic-chain rejection;
+- zero `weight_wrapper_patches` in the active bypass path;
+- projected pruned-AdaLN math through native patches;
+- current ComfyUI import/registration and the existing OpenVDN numerical/oracle suite.
 
-The API-2 mixed-grid path has also been exercised in the production Continuum workflow with Flow-Aligned Regenerate, Spectrum/SA-PECE, DiffAid and Untwisting RoPE across multiple chunk boundaries.
+The API-2 mixed-grid path remains the VDN contract used by the production Flow-Aligned Regenerate Continuum workflow.
 
 ## Upstream and licensing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,46 +1,68 @@
+# ComfyUI-VDN-H3 v1.5.1
+
+v1.5.1 is a hotfix for a production regression introduced by v1.5.0's `lora_mode=bypass` implementation.
+
+## Fixed: stacked runtime adapters on quantized H3
+
+v1.5.0 moved VDN bypass adapters from Comfy's activation-side `BypassForwardHook` mechanism to `ModelPatcher.add_weight_wrapper()` / `weight_function`. On quantized MiniMax-H3 layers, a weight function forces Comfy through a copied/dequantized compute-weight path.
+
+In the production RTX PRO 6000 workflow using:
+
+- an INT8 ConvRot MiniMax-H3 base;
+- VDN `lora_mode=bypass`;
+- an independent runtime-bypass DoRA/LoRA provider on the same H3 modules;
+- `cudaMallocAsync`;
+- Continuum + Flow Mixed-Grid + Spectrum/SA-PECE;
+
+the first actual H3 evaluation hard-aborted with `CUDA error: an illegal memory access was encountered`. The fatal Python stack was inside the external Comfy `BypassForwardHook`/LoRA `F.linear` chain. CUDA errors are asynchronous, so that stack alone does not identify the exact originating kernel, but the regression boundary is the v1.5.0 weight-wrapper path: the previously tested stack-safe VDN bypass-hook implementation worked in the same multi-provider lifecycle.
+
+v1.5.1 therefore restores that validated architecture for ordinary VDN LoRA targets instead of trying another private weight-wrapper variant.
+
+### Bypass ownership in v1.5.1
+
+- Ordinary VDN LoRA targets use Comfy's normal `BypassForwardHook` objects.
+- VDN installs them through one stack-safe `PatcherInjection`.
+- VDN is spliced **inside** an already-active Comfy bypass chain regardless of provider insertion order.
+- VDN can remove itself from the middle of that live chain without restoring stale `module.forward` references.
+- Reapplying VDN on a clone-shared inner model first removes the previous live VDN hook set, preventing accumulated deltas across reruns.
+- Cyclic pre-existing bypass chains fail closed.
+- Fused INT8 `mlp.fc2` targets that bypass `module.forward` remain normal Comfy weight patches.
+- The v1.5.0 runtime `weight_function`/`add_weight_wrapper` path is no longer installed by `lora_mode=bypass`.
+
+This is the same cross-provider lifetime design that was previously validated in the superseded PR #1; PR #1 itself remains closed because v1.5.1 integrates that lifecycle into the newer v1.5 architecture rather than reverting the rest of v1.5.
+
+## Pruned / curve AdaLN behavior
+
+The v1.5 exact pruning-affine work is retained.
+
+Full-width released AdaLN LoRAs are still projected through the resolved `adaln_basis` + `adaln_mean` pair:
+
+```text
+A_pruned   = A @ basis.T
+bias_delta = B @ (A @ mean)
+```
+
+In bypass mode, these already-native projected curve weight/bias terms now use ordinary Comfy `ModelPatcher.add_patches()` ownership. They do not use VDN forward hooks and do not use the v1.5.0 weight-wrapper path.
+
+## Regression coverage
+
+The v1.5.1 suite explicitly covers:
+
+- repeated multi-hook VDN inject/eject cycles;
+- VDN-first and external-provider-first injection ordering;
+- same-order provider teardown in both orders;
+- replacement of a live VDN hook set while an external bypass hook remains active;
+- cyclic-chain fail-closed behavior;
+- `apply_adapters(..., mode="bypass")` creating a VDN injection with **zero weight wrappers**;
+- bypass operation on a plain linear module with no `weight_function` contract;
+- projected curve AdaLN math through native weight/bias patches.
+
+All v1.5.0 work unrelated to the regressed adapter execution mechanism remains: VDN API 2 mixed-grid support, pruned/curve AdaLN projection, branch placement and retained-buffer lifecycle, `cudaMallocAsync` prefetch handling, current Comfy smoke tests, and the legacy `ApplyVDNH3Advanced` widget migration.
+
+---
+
 # ComfyUI-VDN-H3 v1.5.0
 
-v1.5.0 is the correctness/lifecycle and Flow-interop release of the xmarre fork. It reconciles the useful upstream VDN-H3 v1.4.x runtime work while preserving explicit ComfyUI ownership, fixes the Continuum-era adapter recursion path, supports current pruned/INT8 MiniMax-H3 bases, and adds the mixed-grid API used by MiniMax-H3 Flow-Aligned Regenerate.
+v1.5.0 was the correctness/lifecycle and Flow-interoperability release of the xmarre fork. It added the mixed-grid API used by MiniMax-H3 Flow-Aligned Regenerate, current pruned/INT8 MiniMax-H3 support, exact curve-AdaLN projection, branch/runtime lifecycle hardening, upstream v1.4.3 reconciliation, and backwards-compatible Advanced-node workflow migration.
 
-## Highlights
-
-- Replaces the old forward-hook `lora_mode=bypass` implementation with Comfy-managed weight/bias wrappers. VDN no longer traverses or restores LoRA target `module.forward` chains.
-- Preserves `merge` as the conservative reference adapter path while keeping a low-residency runtime mode.
-- Adds fail-closed projection of released full-width AdaLN LoRAs onto supported pruned/curve H3 bases, including the constant bias term from the pruning affine.
-- Adds `branch_weights=auto|stream|resident`, state-owned retained buffers, bounded one-block streaming prefetch, and Comfy-managed BF16 branch residency.
-- Reconciles upstream through v1.4.3. Under `cudaMallocAsync`, explicit `record_stream` bookkeeping is skipped because the allocator is already stream ordered and current torch warns on the no-op calls.
-- Adds external-sequence API 2 / `mixed_grid_low_suffix` for Flow-Aligned Regenerate. Mixed-grid execution keeps the learned dense softmax gate and disables only geometry-dependent local/linear-complement processing while the external mixed sequence is active.
-- Keeps API 1 target-sparse compatibility for existing integrations.
-
-## Legacy Advanced-node workflow migration
-
-PR #2 inserted `retain_buffers` and `architecture_mode` into `ApplyVDNH3Advanced`. Older Comfy workflows stored widget values positionally, so loading the old 14-value layout against the new 16-widget definition could shift values into the wrong widget types.
-
-v1.5.0 ships a frontend migration specifically for those persisted workflows:
-
-- attaches the frontend-native `fallbackWidgetsValuesNames` order for the original 14 widgets;
-- restores all fourteen old values by name;
-- assigns `retain_buffers="auto"`;
-- assigns `architecture_mode="override"` because the old node applied its architecture controls unconditionally;
-- recognizes the short-lived current 16-value positional layout without changing its semantics;
-- leaves workflows that already contain `widgets_values_named` untouched.
-
-The next normal workflow save contains named widget values, so future widget reordering no longer relies on positional interpretation.
-
-## Validation
-
-The release is gated by repository CI before tagging:
-
-- pinned ComfyUI + official OpenVDN numerical/oracle suite;
-- current ComfyUI-main import and compiler-guard smoke;
-- Python static/compile checks;
-- allocator-guard regression for `cudaMallocAsync`;
-- Node.js regression using an actual old 14-value `widgets_values` array, including the `architecture_mode="override"` migration semantic.
-
-Real production testing also exercised the API-2 mixed-grid path together with Flow-Aligned Regenerate, Spectrum/SA-PECE, DiffAid and Untwisting RoPE across multiple Continuum boundaries without the previous LoRA recursion failure.
-
-## Distribution
-
-This GitHub release is built from the exact CI-tested `main` commit and includes a source ZIP plus `SHA256SUMS`.
-
-The fork is released under its own xmarre metadata. OpenVDN, the upstream ComfyUI port, and the released VDN model weights retain their respective upstream ownership and licenses; see `NOTICE` and the README.
+Its `lora_mode=bypass` weight-wrapper implementation is superseded by v1.5.1 because of the stacked runtime-adapter regression described above. `merge` behavior was not implicated.

--- a/docs/UPSTREAM_RECONCILIATION.md
+++ b/docs/UPSTREAM_RECONCILIATION.md
@@ -1,6 +1,6 @@
 # Upstream reconciliation
 
-This fork keeps the released VDN-H3 architecture and tracks the original ComfyUI port while replacing lifecycle mechanisms that conflict with Comfy's model ownership or the Flow-Aligned mixed-grid contract.
+This fork keeps the released VDN-H3 architecture and tracks the original ComfyUI port while adapting lifecycle mechanisms to current Comfy ownership and the Flow-Aligned mixed-grid contract.
 
 ## Reference points
 
@@ -8,9 +8,7 @@ This fork keeps the released VDN-H3 architecture and tracks the original ComfyUI
 - Reconciled upstream head: `b49130c26a70d12c542601c5bc4f7ee0f112ee2e` (`v1.4.3`)
 - Official OpenVDN numerical oracle: `OpenVDN/vdn-minimax-h3@b8cb28fbfca0266d1c7742a9f25ab8b58191de97`
 
-## Upstream v1.4.x work retained in this fork
-
-The useful performance/runtime intent is preserved:
+## Upstream v1.4.x work retained
 
 - VRAM-aware branch placement;
 - optional native INT8 ConvRot branch selection under pressure;
@@ -20,9 +18,9 @@ The useful performance/runtime intent is preserved:
 - the AIMDO malloc-graph compatibility workaround;
 - v1.4.3's `cudaMallocAsync` rule: explicit `record_stream` is skipped when the allocator is already stream ordered.
 
-## Lifecycle differences kept intentionally
+## State ownership differences
 
-The fork does not copy upstream process-global resource ownership verbatim:
+The fork does not retain process-global model-weight ownership:
 
 - no persistent process-global safetensors handles;
 - no private process-global resident GPU branch cache;
@@ -32,14 +30,24 @@ The fork does not copy upstream process-global resource ownership verbatim:
 - nested/concurrent execution that cannot acquire the retained pool receives isolated transient scratch;
 - one-block prefetch uses a single bounded tensor-less executor and at most one state-owned future/result;
 - completed prefetch results cannot be overwritten before `take()` consumes them;
-- prefetch identity includes block, full device identity and compute dtype;
-- Flex BlockMask caching is bounded and keyed by full device/layout identity.
+- Flex BlockMask caching is bounded and keyed by device/layout identity.
 
-## Adapter lifecycle differences
+## Adapter lifecycle: v1.5.1
 
-The old forward-hook LoRA bypass was removed. `lora_mode=bypass` now means Comfy-managed runtime weight/bias wrappers. VDN never traverses, replaces, restores, or chains LoRA target `module.forward` methods.
+`merge` remains normal `ModelPatcher.add_patches()` ownership.
 
-Full-width released AdaLN LoRAs on supported pruned/curve H3 bases are projected through the model's pruning affine, including the required constant bias term.
+For ordinary LoRA targets, `lora_mode=bypass` uses Comfy `BypassForwardHook` objects but **not** the unsafe plain provider lifecycle. VDN wraps those hooks in a stack-safe `PatcherInjection` derived from the production-validated PR #1 fix:
+
+- VDN is inserted inside an already-active independent Comfy bypass chain;
+- VDN can be spliced out while another provider remains active;
+- both provider insertion orders are supported;
+- clone-shared reruns replace the old live VDN hook set instead of accumulating deltas;
+- cyclic existing chains fail closed;
+- fused INT8 `mlp.fc2` targets that bypass `module.forward` remain ordinary weight patches.
+
+v1.5.0 temporarily replaced this with `weight_function` / `add_weight_wrapper` runtime LoRA execution. That path forced quantized H3 layers through Comfy's dequantized compute-weight route and regressed the real stacked VDN + external runtime-DoRA workflow into a CUDA illegal-memory-access abort. v1.5.1 removes that active execution path.
+
+Full-width released AdaLN LoRAs on supported pruned/curve H3 bases are still projected through the exact pruning affine, including the required constant bias term. The already-native projected curve weight/bias terms use normal Comfy patches in both adapter modes.
 
 ## Flow-Aligned external sequence
 
@@ -47,4 +55,4 @@ This fork additionally defines API 2 for `mixed_grid_low_suffix`, used by `xmarr
 
 ## v1.4.3 allocator change
 
-Upstream commit `b49130c26a70d12c542601c5bc4f7ee0f112ee2e` skips `record_stream` under `cudaMallocAsync`. This fork adopts the same allocator condition in `vdn_h3.runtime._StreamPrefetcher`, where this branch actually owns its asynchronous prefetch lifecycle. The behavior is covered by a dedicated regression test.
+Upstream commit `b49130c26a70d12c542601c5bc4f7ee0f112ee2e` skips `record_stream` under `cudaMallocAsync`. This fork applies the same allocator condition in `vdn_h3.runtime._StreamPrefetcher`, where this branch owns its asynchronous prefetch lifecycle. Dedicated regression coverage remains in place.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-vdn-h3"
-version = "1.5.0"
+version = "1.5.1"
 description = "VDN-H3 hybrid attention for ComfyUI's native MiniMax-H3 model"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_bypass_reinject.py
+++ b/tests/test_bypass_reinject.py
@@ -1,341 +1,210 @@
-"""Lifecycle regressions for VDN merge and safe runtime-low-VRAM adapters.
+"""Regression tests for VDN bypass-hook reinjection and cross-provider teardown.
 
-The original Continuum crash was a cyclic ``module.forward`` chain. The restored
-``lora_mode=bypass`` no longer means BypassForwardHook: it is a Comfy-owned
-``weight_function`` wrapper backed by an additional ModelPatcher containing only the
-low-rank A/B tensors.
+ComfyUI's ModelPatcher can have several independently owned bypass injections on
+one module. Plain BypassForwardHook teardown is only safe under a global LIFO
+order, so VDN keeps its hooks inside the external chain and splices them out
+safely regardless of provider insertion/ejection order.
+
+These are the lifecycle invariants from the previously production-validated PR #1
+path. v1.5.1 restores this architecture after the v1.5.0 weight-wrapper path
+regressed a stacked VDN + runtime-DoRA quantized workflow.
 """
 from __future__ import annotations
 
+import types
+
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-import comfy.model_patcher
-import comfy.ops
+import comfy.model_management
+import comfy.patcher_extension
+from comfy.weight_adapter.bypass import BypassForwardHook
 
-from vdn_h3.apply import _RuntimeLoRAWeight, apply_adapters
-from vdn_h3.managed import RuntimeLoRATermsModel
-
-
-def _comfy_linear(dim=8):
-    layer = comfy.ops.disable_weight_init.Linear(
-        dim, dim, bias=False, device="cpu", dtype=torch.float32)
-    with torch.no_grad():
-        layer.weight.copy_(torch.randn(dim, dim))
-    return layer
+from vdn_h3.apply import _FrugalLoRA, _install_injection
 
 
-class Diffusion(nn.Module):
-    def __init__(self, runtime_capable=False):
-        super().__init__()
-        self.linear = _comfy_linear() if runtime_capable else nn.Linear(8, 8, bias=False)
-        self.use_adaln_curves = False
+def _adapter():
+    up = torch.randn(8, 4)
+    down = torch.randn(4, 8) * 0.1
+    return _FrugalLoRA(set(), (up, down, torch.tensor(4.0)))
 
 
-class ToyModel(nn.Module):
-    def __init__(self, runtime_capable=False):
-        super().__init__()
-        self.diffusion_model = Diffusion(runtime_capable=runtime_capable)
-        self.device = torch.device("cpu")
+class _Patcher:
+    def __init__(self, model=None):
+        self.injections = {}
+        self.model = model if model is not None else types.SimpleNamespace()
+
+    def set_injections(self, key, value):
+        self.injections[key] = value
+
+    def inject_model(self):
+        for injections in self.injections.values():
+            for injection in injections:
+                injection.inject(self)
+
+    def eject_model(self):
+        # Deliberately mirrors the hazardous same-order provider teardown that the
+        # VDN splicing logic must survive.
+        for injections in self.injections.values():
+            for injection in injections:
+                injection.eject(self)
 
 
-class ConditioningDiffusion(nn.Module):
-    def __init__(self, runtime_capable=False):
-        super().__init__()
-        self.token_refiner = nn.Module()
-        self.token_refiner.fc1 = (
-            _comfy_linear() if runtime_capable else nn.Linear(8, 8, bias=False))
-        self.transformer_eval = (
-            _comfy_linear() if runtime_capable else nn.Linear(8, 8, bias=False))
-        self.use_adaln_curves = False
-
-    def preprocess_text_embeds(self, x):
-        return torch.nn.functional.silu(self.token_refiner.fc1(x))
-
-    def forward(self, x):
-        return self.transformer_eval(x)
+def _fresh_module():
+    torch.manual_seed(0)
+    mod = nn.Linear(8, 8)
+    return mod, mod.forward
 
 
-class ConditioningToyModel(nn.Module):
-    def __init__(self, runtime_capable=False):
-        super().__init__()
-        self.diffusion_model = ConditioningDiffusion(runtime_capable=runtime_capable)
-        self.device = torch.device("cpu")
+def _adapter_lora(hook, x):
+    up, down, _ = hook.adapter.weights
+    return torch.nn.functional.linear(
+        torch.nn.functional.linear(x, down), up
+    )
 
 
-def _base_patcher(runtime_capable=False):
-    torch.manual_seed(10)
-    return comfy.model_patcher.ModelPatcher(
-        ToyModel(runtime_capable=runtime_capable),
-        torch.device("cpu"), torch.device("cpu"))
+def _external_injection(hook):
+    return comfy.patcher_extension.PatcherInjection(
+        inject=lambda _patcher: hook.inject(),
+        eject=lambda _patcher: hook.eject(),
+    )
 
 
-def _conditioning_base_patcher(runtime_capable=False):
-    torch.manual_seed(11)
-    return comfy.model_patcher.ModelPatcher(
-        ConditioningToyModel(runtime_capable=runtime_capable),
-        torch.device("cpu"), torch.device("cpu"))
+def test_vdn_multiple_hooks_repeated_cycles_restore_true_forward(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    mod, true_fwd = _fresh_module()
+    hook_d = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    hook_t = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    patcher = _Patcher()
+    _install_injection(patcher, [hook_d, hook_t])
+    injection = patcher.injections["vdn_lora"][0]
 
-
-def _converted(seed=20):
-    gen = torch.Generator().manual_seed(seed)
-    a = torch.randn(3, 8, generator=gen)
-    b = torch.randn(8, 3, generator=gen)
-    return {"default": {"linear": (a, b, 1.0)}}
-
-
-def _conditioning_converted(seed=21):
-    gen = torch.Generator().manual_seed(seed)
-    a = torch.randn(3, 8, generator=gen)
-    b = torch.randn(8, 3, generator=gen)
-    return {"default": {"token_refiner.fc1": (a, b, 1.0)}}
-
-
-def _patched_from(base, strength=1.0, seed=20, mode="merge"):
-    patcher = base.clone()
-    report = apply_adapters(
-        patcher, _converted(seed), strength, mode=mode, stage_path=None)
-    if mode == "merge":
-        assert report["default"]["native_weight_patches"] == 1
-    else:
-        assert report["default"]["runtime_weight_targets"] == 1
-        runtime = report["runtime_lowvram"]
-        assert runtime["weight_wrappers"] == 1
-        assert runtime["forward_hooks"] == 0
-        assert runtime["managed_adapter_bytes"] > 0
-        assert runtime["delta_buffer_limit_bytes"] > 0
-        assert runtime["owner_key"].startswith("vdn_runtime_lora_")
-    return patcher
-
-
-def _direct_runtime_wrapper(terms):
-    source = RuntimeLoRATermsModel(
-        {"linear": terms}, torch.device("cpu"))
-    return _RuntimeLoRAWeight(
-        "diffusion_model.linear.weight", "linear", source)
-
-
-def test_runtime_wrapper_matches_explicit_delta_without_mutating_input():
-    torch.manual_seed(1)
-    weight = torch.randn(8, 8)
-    original = weight.clone()
-    a1 = torch.randn(3, 8)
-    b1 = torch.randn(8, 3)
-    a2 = torch.randn(2, 8)
-    b2 = torch.randn(8, 2)
-    wrapper = _direct_runtime_wrapper(
-        [(a1, b1, 0.75), (a2, b2, -0.2)])
-
-    got = wrapper(weight)
-    expected = weight + 0.75 * (b1 @ a1) - 0.2 * (b2 @ a2)
-    assert torch.allclose(got, expected, atol=2e-6, rtol=2e-6)
-    assert torch.equal(weight, original)
-    assert not hasattr(wrapper, "prepared_patches")
-    assert not hasattr(wrapper, "original_forward")
-
-
-def test_runtime_mode_registers_weight_wrapper_not_injection_or_forward_patch():
-    base = _base_patcher(runtime_capable=True)
-    module = base.model.diffusion_model.linear
-    original_forward = module.forward.__func__
-    vdn = _patched_from(base, mode="bypass")
-
-    assert not vdn.injections
-    assert not any(key.endswith("linear.forward") for key in vdn.object_patches)
-    wrappers = vdn.weight_wrapper_patches["diffusion_model.linear.weight"]
-    assert len(wrappers) == 1
-    assert wrappers[0]._vdn_runtime_lora is True
-    assert wrappers[0].source.term_count() == 1
-    runtime_keys = [k for k in vdn.additional_models if k.startswith("vdn_runtime_lora_")]
-    assert len(runtime_keys) == 1
-    assert module.forward.__func__ is original_forward
-
-
-def test_runtime_mode_fails_closed_without_weight_function_contract():
-    base = _base_patcher(runtime_capable=False)
-    clone = base.clone()
-    try:
-        apply_adapters(clone, _converted(), 1.0, mode="bypass", stage_path=None)
-    except RuntimeError as exc:
-        assert "weight_function" in str(exc)
-        assert "merge" in str(exc)
-    else:
-        raise AssertionError("runtime mode accepted an unsupported plain nn.Linear")
-
-
-def test_native_patch_does_not_replace_forward():
-    base = _base_patcher()
-    module = base.model.diffusion_model.linear
-    true_func = module.forward.__func__
-    _patched_from(base)
-    assert module.forward.__func__ is true_func
-
-
-def test_repeated_merge_clone_load_unload_is_stable_and_restores_base():
-    base = _base_patcher()
-    module = base.model.diffusion_model.linear
-    original = module.weight.detach().clone()
-    x = torch.randn(4, 8)
-    reference = None
-
-    vdn = _patched_from(base, strength=1.0)
-    for chunk in range(8):
-        clone = vdn.clone()
-        clone.patch_model(device_to=torch.device("cpu"))
-        got = module(x).detach().clone()
-        if reference is None:
-            reference = got
-        else:
-            assert torch.allclose(got, reference, atol=1e-6, rtol=1e-6), chunk
-        clone.unpatch_model(device_to=torch.device("cpu"))
-        assert torch.equal(module.weight, original), chunk
-
-
-def test_repeated_runtime_clone_load_unload_is_stable_and_never_merges_base():
-    base = _base_patcher(runtime_capable=True)
-    module = base.model.diffusion_model.linear
-    original = module.weight.detach().clone()
-    original_forward = module.forward.__func__
-    x = torch.randn(4, 8)
-    reference = None
-
-    vdn = _patched_from(base, strength=1.0, mode="bypass")
-    for chunk in range(12):
-        clone = vdn.clone()
-        clone.patch_model(device_to=torch.device("cpu"))
-        assert torch.equal(module.weight, original), chunk
-        assert module.forward.__func__ is original_forward
-        got = module(x).detach().clone()
-        if reference is None:
-            reference = got
-        else:
-            assert torch.allclose(got, reference, atol=1e-6, rtol=1e-6), chunk
-        clone.unpatch_model(device_to=torch.device("cpu"))
-        assert torch.equal(module.weight, original), chunk
-        assert module.forward.__func__ is original_forward
-
-
-def test_continuum_conditioning_then_forward_survives_runtime_mode_repeated_clones():
-    base = _conditioning_base_patcher(runtime_capable=True)
-    dm = base.model.diffusion_model
-    original_fc1 = dm.token_refiner.fc1.weight.detach().clone()
-    original_forward = dm.token_refiner.fc1.forward.__func__
-    x = torch.randn(5, 8)
-
-    vdn = base.clone()
-    report = apply_adapters(
-        vdn, _conditioning_converted(), 1.0, mode="bypass", stage_path=None)
-    assert report["default"]["runtime_weight_targets"] == 1
-    assert not vdn.injections
-
-    conditioning_reference = None
-    forward_reference = None
-    for chunk in range(12):
-        chunk_model = vdn.clone()
-        chunk_model.patch_model(device_to=torch.device("cpu"))
-
-        conditioning = dm.preprocess_text_embeds(x).detach().clone()
-        transformed = dm(x).detach().clone()
-        assert dm.token_refiner.fc1.forward.__func__ is original_forward
-        assert torch.equal(dm.token_refiner.fc1.weight, original_fc1)
-
-        if conditioning_reference is None:
-            conditioning_reference = conditioning
-            forward_reference = transformed
-        else:
-            assert torch.allclose(
-                conditioning, conditioning_reference, atol=1e-6, rtol=1e-6), chunk
-            assert torch.allclose(
-                transformed, forward_reference, atol=1e-6, rtol=1e-6), chunk
-
-        chunk_model.unpatch_model(device_to=torch.device("cpu"))
-        assert torch.equal(dm.token_refiner.fc1.weight, original_fc1), chunk
-        assert dm.token_refiner.fc1.forward.__func__ is original_forward
-
-
-def test_runtime_strength_change_reapplies_from_true_base_not_previous_delta():
-    base = _base_patcher(runtime_capable=True)
-    module = base.model.diffusion_model.linear
-    original = module.weight.detach().clone()
     x = torch.randn(3, 8)
-    y0 = F.linear(x, original)
+    want = true_fwd(x) + _adapter_lora(hook_d, x) + _adapter_lora(hook_t, x)
 
-    one = _patched_from(base, strength=1.0, mode="bypass")
-    half = _patched_from(base, strength=0.5, mode="bypass")
+    for cycle in range(5):
+        injection.inject(patcher)
+        assert mod.forward == hook_d._bypass_forward, cycle
+        assert hook_d.original_forward == hook_t._bypass_forward, cycle
+        assert hook_t.original_forward == true_fwd, cycle
+        assert torch.allclose(mod(x), want, atol=1e-5), cycle
 
-    # Comfy currently does not compare weight_wrapper_patches inside
-    # clone_has_same_weights(). Distinct runtime-owner keys therefore deliberately
-    # make differently configured Apply results non-equivalent, forcing model
-    # management to reload rather than reusing a stale wrapper set.
-    assert set(one.additional_models) != set(half.additional_models)
-    assert not one.clone_has_same_weights(half)
-
-    one.patch_model(device_to=torch.device("cpu"))
-    y1 = module(x).detach().clone()
-    one.unpatch_model(device_to=torch.device("cpu"))
-    assert torch.equal(module.weight, original)
-
-    half.patch_model(device_to=torch.device("cpu"))
-    yhalf = module(x).detach().clone()
-    half.unpatch_model(device_to=torch.device("cpu"))
-    assert torch.equal(module.weight, original)
-
-    assert torch.allclose(yhalf - y0, 0.5 * (y1 - y0), atol=1e-5, rtol=1e-5)
+        injection.eject(patcher)
+        assert mod.forward == true_fwd, cycle
+        assert hook_d.original_forward is None
+        assert hook_t.original_forward is None
 
 
-def test_runtime_clone_retains_same_owner_and_is_weight_equivalent():
-    base = _base_patcher(runtime_capable=True)
-    vdn = _patched_from(base, strength=0.75, mode="bypass")
-    clone = vdn.clone()
+def _run_cross_provider_cycles(monkeypatch, vdn_first):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    mod, true_fwd = _fresh_module()
+    vdn_hook = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    external_hook = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    patcher = _Patcher()
 
-    assert set(vdn.additional_models) == set(clone.additional_models)
-    assert vdn.clone_has_same_weights(clone)
+    if vdn_first:
+        _install_injection(patcher, [vdn_hook])
+        patcher.set_injections(
+            "external_runtime_lora", [_external_injection(external_hook)]
+        )
+    else:
+        patcher.set_injections(
+            "external_runtime_lora", [_external_injection(external_hook)]
+        )
+        _install_injection(patcher, [vdn_hook])
+
+    x = torch.randn(3, 8)
+    want = (
+        true_fwd(x)
+        + _adapter_lora(vdn_hook, x)
+        + _adapter_lora(external_hook, x)
+    )
+
+    for cycle in range(5):
+        patcher.inject_model()
+
+        # External provider is outermost in both insertion orders; VDN is safely
+        # spliced underneath it and above the true base forward.
+        assert mod.forward == external_hook._bypass_forward, cycle
+        assert external_hook.original_forward == vdn_hook._bypass_forward, cycle
+        assert vdn_hook.original_forward == true_fwd, cycle
+        assert torch.allclose(mod(x), want, atol=1e-5), cycle
+
+        patcher.eject_model()
+        assert mod.forward == true_fwd, cycle
+        assert vdn_hook.original_forward is None
+        assert external_hook.original_forward is None
 
 
-def test_external_forward_owner_is_never_mutated_by_runtime_lifecycle():
-    base = _base_patcher(runtime_capable=True)
-    module = base.model.diffusion_model.linear
-    true_forward = module.forward
-    calls = {"n": 0}
+def test_cross_provider_forward_order_eject_vdn_first(monkeypatch):
+    _run_cross_provider_cycles(monkeypatch, vdn_first=True)
 
-    def external_forward(x):
-        calls["n"] += 1
-        return true_forward(x)
 
-    module.forward = external_forward
-    vdn = _patched_from(base, mode="bypass")
+def test_cross_provider_forward_order_eject_external_first(monkeypatch):
+    _run_cross_provider_cycles(monkeypatch, vdn_first=False)
+
+
+def test_live_vdn_replacement_under_external_hook(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    mod, true_fwd = _fresh_module()
+    shared_owner = types.SimpleNamespace()
+    first = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    second = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    external = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+
+    patcher1 = _Patcher(shared_owner)
+    _install_injection(patcher1, [first])
+    inj1 = patcher1.injections["vdn_lora"][0]
+    inj1.inject(patcher1)
+    external.inject()
+
+    assert mod.forward == external._bypass_forward
+    assert external.original_forward == first._bypass_forward
+
+    patcher2 = _Patcher(shared_owner)
+    _install_injection(patcher2, [second])
+    inj2 = patcher2.injections["vdn_lora"][0]
+    inj2.inject(patcher2)
+
+    assert first.original_forward is None
+    assert mod.forward == external._bypass_forward
+    assert external.original_forward == second._bypass_forward
+    assert second.original_forward == true_fwd
+
     x = torch.randn(2, 8)
-    for _ in range(5):
-        clone = vdn.clone()
-        assert module.forward is external_forward
-        clone.patch_model(device_to=torch.device("cpu"))
-        module(x)
-        assert module.forward is external_forward
-        clone.unpatch_model(device_to=torch.device("cpu"))
-        assert module.forward is external_forward
-    assert calls["n"] == 5
+    want = true_fwd(x) + _adapter_lora(second, x) + _adapter_lora(external, x)
+    assert torch.allclose(mod(x), want, atol=1e-5)
+
+    inj2.eject(patcher2)
+    assert mod.forward == external._bypass_forward
+    assert external.original_forward == true_fwd
+    external.eject()
+    assert mod.forward == true_fwd
 
 
-def test_runtime_mode_aggregates_multiple_adapters_into_one_weight_wrapper():
-    base = _base_patcher(runtime_capable=True)
-    gen = torch.Generator().manual_seed(30)
-    a1, b1 = torch.randn(2, 8, generator=gen), torch.randn(8, 2, generator=gen)
-    a2, b2 = torch.randn(3, 8, generator=gen), torch.randn(8, 3, generator=gen)
-    converted = {
-        "default": {"linear": (a1, b1, 1.0)},
-        "turbo": {"linear": (a2, b2, 0.5)},
-    }
-    patcher = base.clone()
-    apply_adapters(
-        patcher, converted, {"default": 0.75, "turbo": 1.2},
-        mode="bypass", stage_path=None)
+def test_cycle_detection_fails_closed(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    mod, _ = _fresh_module()
+    external = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    external.inject()
+    external.original_forward = external._bypass_forward
 
-    wrappers = patcher.weight_wrapper_patches["diffusion_model.linear.weight"]
-    assert len(wrappers) == 1
-    assert wrappers[0].source.term_count() == 2
+    vdn = BypassForwardHook(mod, _adapter(), multiplier=1.0)
+    patcher = _Patcher()
+    _install_injection(patcher, [vdn])
+    injection = patcher.injections["vdn_lora"][0]
 
-    weight = base.model.diffusion_model.linear.weight.detach()
-    expected_weight = weight + 0.75 * (b1 @ a1) + (1.2 * 0.5) * (b2 @ a2)
-    got_weight = wrappers[0](weight)
-    assert torch.allclose(got_weight, expected_weight, atol=2e-6, rtol=2e-6)
+    try:
+        injection.inject(patcher)
+    except RuntimeError as exc:
+        assert "cyclic Comfy bypass-forward chain" in str(exc)
+    else:
+        raise AssertionError("cyclic bypass chain was accepted")

--- a/tests/test_curve_apply.py
+++ b/tests/test_curve_apply.py
@@ -1,29 +1,19 @@
 from __future__ import annotations
 
 import torch
+from safetensors.torch import save_file
 from torch import nn
 from torch.nn import functional as F
-from safetensors.torch import save_file
 
 import comfy.model_patcher
 
 from vdn_h3.apply import apply_adapters
 
 
-class MarkedLinear(nn.Linear):
-    def __init__(self, in_features, out_features):
-        super().__init__(in_features, out_features, bias=True)
-        # Current Comfy castable Linear modules expose these lists. Runtime VDN
-        # targets them through ModelPatcher.add_weight_wrapper; module.forward stays
-        # untouched.
-        self.weight_function = []
-        self.bias_function = []
-
-
 class Adaln(nn.Module):
     def __init__(self, curve_width, out):
         super().__init__()
-        self.linear = MarkedLinear(curve_width, out)
+        self.linear = nn.Linear(curve_width, out, bias=True)
         self.apply_silu = False
 
 
@@ -50,7 +40,8 @@ class Root(nn.Module):
 
 def _patcher(table, out):
     return comfy.model_patcher.ModelPatcher(
-        Root(table, out), torch.device("cpu"), torch.device("cpu"))
+        Root(table, out), torch.device("cpu"), torch.device("cpu")
+    )
 
 
 def _stage(tmp_path, basis, mean):
@@ -58,42 +49,55 @@ def _stage(tmp_path, basis, mean):
     stage.mkdir()
     save_file(
         {"adaln_basis": basis.float(), "adaln_mean": mean.float()},
-        stage / "adaln_affine.safetensors")
+        stage / "adaln_affine.safetensors",
+    )
     return stage
 
 
-def test_curve_bypass_uses_weight_and_bias_wrappers_without_forward_patch(tmp_path):
-    torch.manual_seed(421)
-    table = torch.randn(9, 3)
-    dense, rank, out = 7, 2, 6
-    basis = torch.randn(3, dense)
-    mean = torch.randn(dense)
-    stage = _stage(tmp_path, basis, mean)
-    patcher = _patcher(table, out)
-    forward_before = patcher.get_model_object(
-        "diffusion_model.blocks.0.adaln_proj").forward
-    converted = {
+def _converted(dense, rank, out, scale=1.0):
+    return {
         "turbo": {
             "blocks.0.adaln_proj.linear": (
-                torch.randn(rank, dense), torch.randn(out, rank), 1.0)
+                torch.randn(rank, dense),
+                torch.randn(out, rank),
+                scale,
+            )
         }
     }
 
+
+def test_curve_bypass_uses_native_projected_patches_not_weight_wrappers(tmp_path):
+    torch.manual_seed(421)
+    table = torch.randn(9, 3)
+    dense, rank, out = 7, 2, 6
+    stage = _stage(tmp_path, torch.randn(3, dense), torch.randn(dense))
+    patcher = _patcher(table, out)
+
     report = apply_adapters(
-        patcher, converted, 0.75, mode="bypass", stage_path=str(stage))
+        patcher,
+        _converted(dense, rank, out),
+        0.75,
+        mode="bypass",
+        stage_path=str(stage),
+    )
 
     weight_key = "diffusion_model.blocks.0.adaln_proj.linear.weight"
     bias_key = "diffusion_model.blocks.0.adaln_proj.linear.bias"
-    assert weight_key in patcher.weight_wrapper_patches
-    assert bias_key in patcher.weight_wrapper_patches
-    assert len(patcher.weight_wrapper_patches[weight_key]) == 1
-    assert len(patcher.weight_wrapper_patches[bias_key]) == 1
-    assert patcher.object_patches == {}
-    assert patcher.get_model_object(
-        "diffusion_model.blocks.0.adaln_proj").forward == forward_before
-    assert report["runtime_lowvram"]["bias_wrappers"] == 1
-    assert report["curve_adaln_projection"]["curve_width"] == 3
-    assert report["curve_adaln_projection"]["dense_width"] == dense
+    assert weight_key in patcher.patches
+    assert bias_key in patcher.patches
+    assert patcher.weight_wrapper_patches == {}
+    # Curve-only bypass has nothing to activation-hook; its exact projected
+    # native terms are ordinary Comfy weight/bias patches.
+    assert patcher.injections == {}
+    assert report["runtime_lowvram"]["weight_wrappers"] == 0
+    assert report["runtime_lowvram"]["bias_wrappers"] == 0
+    assert report["runtime_lowvram"]["forward_hooks"] == 0
+    assert (
+        report["curve_adaln_projection"]["mode"]
+        == "bypass_native_projected_patch"
+    )
+    assert report["curve_adaln_projection"]["weight_patches"] == 1
+    assert report["curve_adaln_projection"]["bias_patches"] == 1
 
 
 def test_curve_merge_registers_normal_weight_and_bias_patches(tmp_path):
@@ -102,52 +106,27 @@ def test_curve_merge_registers_normal_weight_and_bias_patches(tmp_path):
     dense, rank, out = 7, 2, 6
     stage = _stage(tmp_path, torch.randn(3, dense), torch.randn(dense))
     patcher = _patcher(table, out)
-    converted = {
-        "turbo": {
-            "blocks.0.adaln_proj.linear": (
-                torch.randn(rank, dense), torch.randn(out, rank), 0.8)
-        }
-    }
 
     report = apply_adapters(
-        patcher, converted, 0.5, mode="merge", stage_path=str(stage))
+        patcher,
+        _converted(dense, rank, out, scale=0.8),
+        0.5,
+        mode="merge",
+        stage_path=str(stage),
+    )
 
     weight_key = "diffusion_model.blocks.0.adaln_proj.linear.weight"
     bias_key = "diffusion_model.blocks.0.adaln_proj.linear.bias"
     assert weight_key in patcher.patches
     assert bias_key in patcher.patches
     assert patcher.weight_wrapper_patches == {}
-    assert patcher.object_patches == {}
+    assert patcher.injections == {}
     assert report["curve_adaln_projection"]["mode"] == "merge"
     assert report["curve_adaln_projection"]["weight_patches"] == 1
     assert report["curve_adaln_projection"]["bias_patches"] == 1
 
 
-def test_curve_bypass_managed_model_owns_projected_bias_offset(tmp_path):
-    torch.manual_seed(423)
-    table = torch.randn(9, 3)
-    dense, rank, out = 7, 2, 6
-    stage = _stage(tmp_path, torch.randn(3, dense), torch.randn(dense))
-    patcher = _patcher(table, out)
-    converted = {
-        "turbo": {
-            "blocks.0.adaln_proj.linear": (
-                torch.randn(rank, dense), torch.randn(out, rank), 1.0)
-        }
-    }
-
-    report = apply_adapters(
-        patcher, converted, 1.0, mode="bypass", stage_path=str(stage))
-    owner_key = report["runtime_lowvram"]["owner_key"]
-    managed_patcher = patcher.get_additional_models_with_key(owner_key)[0]
-    managed = managed_patcher.model
-
-    assert managed.term_count() == 1
-    assert managed.bias_term_count() == 1
-    assert any(p.dtype == torch.float32 and p.numel() == out for p in managed.parameters())
-
-
-def test_curve_bypass_weight_plus_bias_wrapper_matches_affine_dense_delta(tmp_path):
+def test_curve_bypass_projected_patch_matches_affine_dense_delta(tmp_path):
     torch.manual_seed(424)
     table = torch.randn(9, 3)
     dense, rank, out = 7, 2, 6
@@ -155,7 +134,9 @@ def test_curve_bypass_weight_plus_bias_wrapper_matches_affine_dense_delta(tmp_pa
     mean = torch.randn(dense)
     stage = _stage(tmp_path, basis, mean)
     patcher = _patcher(table, out)
-    linear = patcher.get_model_object("diffusion_model.blocks.0.adaln_proj.linear")
+    linear = patcher.get_model_object(
+        "diffusion_model.blocks.0.adaln_proj.linear"
+    )
     base_weight = linear.weight.detach().clone()
     base_bias = linear.bias.detach().clone()
     a = torch.randn(rank, dense)
@@ -169,15 +150,19 @@ def test_curve_bypass_weight_plus_bias_wrapper_matches_affine_dense_delta(tmp_pa
         mode="bypass",
         stage_path=str(stage),
     )
-    weight_key = "diffusion_model.blocks.0.adaln_proj.linear.weight"
-    bias_key = "diffusion_model.blocks.0.adaln_proj.linear.bias"
-    wrapped_weight = patcher.weight_wrapper_patches[weight_key][0](base_weight)
-    wrapped_bias = patcher.weight_wrapper_patches[bias_key][0](base_bias)
 
     coords = torch.randn(5, 3)
-    got = F.linear(coords, wrapped_weight, wrapped_bias)
     dense_input = mean + coords @ basis
     expected = F.linear(coords, base_weight, base_bias) + F.linear(
-        F.linear(dense_input, a), b) * strength
+        F.linear(dense_input, a), b
+    ) * strength
 
-    assert torch.allclose(got, expected, atol=2e-5, rtol=2e-5)
+    patcher.patch_model(device_to=torch.device("cpu"))
+    try:
+        got = F.linear(coords, linear.weight, linear.bias)
+        assert torch.allclose(got, expected, atol=2e-5, rtol=2e-5)
+    finally:
+        patcher.unpatch_model(device_to=torch.device("cpu"))
+
+    assert torch.equal(linear.weight, base_weight)
+    assert torch.equal(linear.bias, base_bias)

--- a/tests/test_quantized_patch.py
+++ b/tests/test_quantized_patch.py
@@ -10,20 +10,17 @@ from vdn_h3.apply import apply_adapters
 
 
 class QuantizedLikeLinear(nn.Module):
-    """Synthetic Comfy custom-weight module exercising both adapter lifecycles.
+    """Synthetic custom-weight module for merge and activation-bypass lifecycles.
 
     ``convert_weight`` / ``set_weight`` stand in for dequantize/requantize in the
-    eager merge path. ``weight_function`` is the core-supported runtime path used by
-    Comfy castable linears. This is deliberately not a fake quantizer; it proves VDN
-    chooses the correct lifecycle abstraction without changing ``module.forward``.
+    eager merge path. ``weight_function`` remains present specifically so the
+    bypass regression can assert that v1.5.1 no longer installs a weight wrapper
+    or forces this custom-weight module onto that path.
     """
 
     def __init__(self, dim=8):
         super().__init__()
         self.weight = nn.Parameter(torch.randn(dim, dim), requires_grad=False)
-        # Comfy's castable-module loader queries both `.weight` and `.bias`, even
-        # when the module is bias-free. Real comfy.ops.Linear objects expose
-        # `bias=None`, so the synthetic fixture must do the same.
         self.bias = None
         self.convert_calls = 0
         self.set_calls = 0
@@ -123,12 +120,12 @@ def test_custom_weight_patch_repeated_clone_cycles_do_not_accumulate():
         assert torch.equal(module.weight, base_weight), cycle
 
 
-def test_runtime_lowvram_custom_weight_does_not_eager_merge_or_set_weight():
+def test_bypass_custom_weight_preserves_native_weight_path():
     torch.manual_seed(73)
     model, patcher = _patcher()
     module = model.diffusion_model.fc2
     base_weight = module.weight.detach().clone()
-    base_forward = module.forward.__func__
+    true_forward = module.forward
     a = torch.randn(3, 8)
     b = torch.randn(8, 3)
 
@@ -136,43 +133,45 @@ def test_runtime_lowvram_custom_weight_does_not_eager_merge_or_set_weight():
         patcher, {"default": {"fc2": (a, b, 1.0)}},
         1.0, mode="bypass", stage_path=None)
     assert report["default"]["native_weight_patches"] == 0
-    assert report["default"]["runtime_weight_targets"] == 1
+    assert report["default"]["runtime_bypass_targets"] == 1
     assert not patcher.patches
-    assert not patcher.injections
-    assert module.forward.__func__ is base_forward
+    assert "vdn_lora" in patcher.injections
+    assert not patcher.weight_wrapper_patches
+    assert module.forward == true_forward
 
     patcher.patch_model(device_to=torch.device("cpu"))
-    # Runtime low-VRAM mode does not materialize/requantize a patched resident
-    # parameter during load. The base representation stays untouched.
-    assert module.convert_calls == 0
-    assert module.set_calls == 0
+    try:
+        # The hotfix must not materialize/requantize a patched base parameter and
+        # must not install a weight_function on the custom/quantized base layer.
+        assert module.convert_calls == 0
+        assert module.set_calls == 0
+        assert torch.equal(module.weight, base_weight)
+        assert len(module.weight_function) == 0
+        assert module.forward != true_forward
+
+        x = torch.randn(4, 8)
+        expected = F.linear(x, base_weight) + F.linear(F.linear(x, a), b)
+        got = module(x)
+        assert torch.allclose(got, expected, atol=2e-6, rtol=2e-6)
+        assert torch.equal(module.weight, base_weight)
+    finally:
+        patcher.unpatch_model(device_to=torch.device("cpu"))
+
     assert torch.equal(module.weight, base_weight)
-    assert module.forward.__func__ is base_forward
-    assert len(module.weight_function) == 1
-
-    x = torch.randn(4, 8)
-    expected_weight = base_weight + b @ a
-    got = module(x)
-    assert torch.allclose(
-        got, F.linear(x, expected_weight), atol=2e-6, rtol=2e-6)
-    assert torch.equal(module.weight, base_weight)
-
-    patcher.unpatch_model(device_to=torch.device("cpu"))
-    assert torch.equal(module.weight, base_weight)
-    assert module.forward.__func__ is base_forward
-    # Full-load unpatch restores parameters but Comfy may retain the cast wrapper
-    # list until the next load. VDN does not own or mutate that cleanup policy.
+    assert len(module.weight_function) == 0
+    assert module.forward == true_forward
 
 
-def test_runtime_lowvram_repeated_custom_weight_clone_cycles_do_not_accumulate():
+def test_bypass_repeated_custom_weight_clone_cycles_do_not_accumulate():
     torch.manual_seed(74)
     model, patcher = _patcher()
     module = model.diffusion_model.fc2
     base_weight = module.weight.detach().clone()
+    true_forward = module.forward
     a = torch.randn(2, 8)
     b = torch.randn(8, 2)
     x = torch.randn(3, 8)
-    expected = F.linear(x, base_weight + b @ a)
+    expected = F.linear(x, base_weight) + F.linear(F.linear(x, a), b)
 
     apply_adapters(
         patcher, {"default": {"fc2": (a, b, 1.0)}},
@@ -181,8 +180,12 @@ def test_runtime_lowvram_repeated_custom_weight_clone_cycles_do_not_accumulate()
     for cycle in range(8):
         clone = patcher.clone()
         clone.patch_model(device_to=torch.device("cpu"))
-        assert len(module.weight_function) == 1, cycle
-        assert torch.allclose(module(x), expected, atol=2e-6, rtol=2e-6), cycle
-        assert torch.equal(module.weight, base_weight), cycle
-        clone.unpatch_model(device_to=torch.device("cpu"))
+        try:
+            assert len(module.weight_function) == 0, cycle
+            assert module.forward != true_forward, cycle
+            assert torch.allclose(module(x), expected, atol=2e-6, rtol=2e-6), cycle
+            assert torch.equal(module.weight, base_weight), cycle
+        finally:
+            clone.unpatch_model(device_to=torch.device("cpu"))
+        assert module.forward == true_forward, cycle
         assert torch.equal(module.weight, base_weight), cycle

--- a/tests/test_runtime_lowvram.py
+++ b/tests/test_runtime_lowvram.py
@@ -3,150 +3,110 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-import comfy.lora
 import comfy.model_management
 import comfy.model_patcher
 
-from vdn_h3.adapters import convert_adapter
-from vdn_h3.apply import (
-    _RuntimeLoRAWeight,
-    _comfy_lora,
-    _validate_runtime_weight_targets,
-)
-from vdn_h3.managed import (
-    RuntimeLoRATermsModel,
-    make_managed_runtime_lora_patcher,
-)
+from vdn_h3.apply import apply_adapters
 
 
-class BaseModel(nn.Module):
+class Diffusion(nn.Module):
     def __init__(self):
         super().__init__()
-        self.anchor = nn.Parameter(torch.ones(1), requires_grad=False)
+        self.linear = nn.Linear(8, 8, bias=False)
+        self.use_adaln_curves = False
+
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.diffusion_model = Diffusion()
         self.device = torch.device("cpu")
 
 
 def _base_patcher():
+    torch.manual_seed(10)
     return comfy.model_patcher.ModelPatcher(
-        BaseModel(), torch.device("cpu"), torch.device("cpu"))
+        ToyModel(), torch.device("cpu"), torch.device("cpu")
+    )
 
 
-def test_managed_runtime_terms_preserve_checkpoint_dtype_and_clone_identity():
-    a = torch.randn(3, 8, dtype=torch.bfloat16)
-    b = torch.randn(8, 3, dtype=torch.bfloat16)
-    terms = {"linear": [(a, b, 0.75)]}
+def _converted(seed=20):
+    gen = torch.Generator().manual_seed(seed)
+    a = torch.randn(3, 8, generator=gen)
+    b = torch.randn(8, 3, generator=gen)
+    return {"default": {"linear": (a, b, 1.0)}}, a, b
+
+
+def test_bypass_apply_uses_injection_and_never_weight_wrappers(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
     base = _base_patcher()
-    model, patcher = make_managed_runtime_lora_patcher(terms, base)
+    module = base.model.diffusion_model.linear
+    true_forward = module.forward
+    converted, a, b = _converted()
 
-    params = list(model.parameters())
-    assert len(params) == 2
-    assert all(p.dtype == torch.bfloat16 for p in params)
-    assert model.term_count() == 1
-    assert patcher.model_size() == sum(p.numel() * p.element_size() for p in params)
-
-    applied = base.clone()
-    applied.set_additional_models("vdn_runtime_lora", [patcher])
-    clone = applied.clone()
-    cloned = clone.get_additional_models_with_key("vdn_runtime_lora")[0]
-    assert cloned is not patcher
-    assert cloned.model is model
-    assert [id(p) for p in cloned.model.parameters()] == [id(p) for p in params]
-
-
-def test_runtime_weight_math_matches_comfy_merge_adapter_math_float32():
-    torch.manual_seed(123)
-    weight = torch.randn(8, 8, dtype=torch.float32)
-    a = torch.randn(3, 8, dtype=torch.float32)
-    b = torch.randn(8, 3, dtype=torch.float32)
-    scale = 0.75
-    strength = 0.6
-    key = "diffusion_model.linear.weight"
-
-    raw = _comfy_lora({"linear": (a, b, scale)})
-    loaded = comfy.lora.load_lora(raw, {"linear": key}, log_missing=False)
-    adapter = loaded[key]
-    compute_dtype = comfy.model_management.lora_compute_dtype(weight.device)
-    if compute_dtype is None:
-        compute_dtype = weight.dtype
-    expected = adapter.calculate_weight(
-        weight.to(dtype=compute_dtype, copy=True),
-        key,
-        strength,
-        1.0,
-        None,
-        lambda x: x,
-        intermediate_dtype=compute_dtype,
+    vdn = base.clone()
+    report = apply_adapters(
+        vdn, converted, 0.75, mode="bypass", stage_path=None
     )
 
-    source = RuntimeLoRATermsModel(
-        {"linear": [(a, b, scale * strength)]}, torch.device("cpu"))
-    wrapper = _RuntimeLoRAWeight(key, "linear", source)
-    got = wrapper(weight)
+    assert "vdn_lora" in vdn.injections
+    assert vdn.weight_wrapper_patches == {}
+    assert report["default"]["runtime_bypass_targets"] == 1
+    assert report["default"]["runtime_weight_targets"] == 1
+    runtime = report["runtime_lowvram"]
+    assert runtime["mode"] == "stack_safe_bypass"
+    assert runtime["forward_hooks"] == 1
+    assert runtime["weight_wrappers"] == 0
+    assert runtime["bias_wrappers"] == 0
+    assert runtime["managed_adapter_bytes"] == 0
+    assert runtime["owner_key"] is None
+    assert runtime["stack_safe_cross_provider"] is True
 
-    assert torch.equal(got, expected)
-
-
-def test_runtime_delta_buffer_is_bounded_independently_of_full_weight_size():
-    source = RuntimeLoRATermsModel(
-        {"linear": [(torch.zeros(2, 8192), torch.zeros(16384, 2), 1.0)]},
-        torch.device("cpu"),
+    x = torch.randn(4, 8)
+    base_out = true_forward(x)
+    want = base_out + 0.75 * torch.nn.functional.linear(
+        torch.nn.functional.linear(x, a), b
     )
-    wrapper = _RuntimeLoRAWeight(
-        "diffusion_model.linear.weight", "linear", source)
-    out = torch.empty(16384, 8192, dtype=torch.bfloat16)
-    rows = wrapper._rows_per_chunk(out, 8192)
-    assert rows >= 1
-    assert rows * 8192 * out.element_size() <= (8 << 20)
-    assert rows < out.shape[0]
+
+    injection = vdn.injections["vdn_lora"][0]
+    injection.inject(vdn)
+    try:
+        got = module(x)
+        assert torch.allclose(got, want, atol=1e-5, rtol=1e-5)
+    finally:
+        injection.eject(vdn)
+
+    assert module.forward == true_forward
 
 
-def test_openvdn_token_refiner_targets_validate_against_comfy_fused_modules():
-    rank, hidden, inner = 2, 5, 4
+def test_merge_apply_stays_on_normal_weight_patches():
+    base = _base_patcher()
+    converted, _, _ = _converted()
+    merged = base.clone()
 
-    def marked_linear(in_features, out_features):
-        layer = nn.Linear(in_features, out_features, bias=False)
-        layer.weight_function = None
-        return layer
+    report = apply_adapters(
+        merged, converted, 1.0, mode="merge", stage_path=None
+    )
 
-    class Attention(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.qkv_proj = marked_linear(hidden, inner * 3)
-            self.out_proj = marked_linear(inner, hidden)
+    assert merged.injections == {}
+    assert merged.weight_wrapper_patches == {}
+    assert "diffusion_model.linear.weight" in merged.patches
+    assert report["default"]["native_weight_patches"] == 1
+    assert report["default"]["runtime_bypass_targets"] == 0
 
-    class RefinerBlock(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.attn = Attention()
 
-    class TokenRefiner(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.blocks = nn.ModuleList([RefinerBlock()])
-
-    class DiffusionModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.token_refiner = TokenRefiner()
-
-    class Root(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.diffusion_model = DiffusionModel()
-            self.device = torch.device("cpu")
-
-    state = {}
-    for suffix in ("to_q", "to_k", "to_v"):
-        module = f"token_refiner.refiner_blocks.0.attn.{suffix}"
-        state[f"{module}.lora_A.weight"] = torch.randn(rank, hidden)
-        state[f"{module}.lora_B.weight"] = torch.randn(inner, rank)
-    out_module = "token_refiner.refiner_blocks.0.attn.to_out.0"
-    state[f"{out_module}.lora_A.weight"] = torch.randn(rank, inner)
-    state[f"{out_module}.lora_B.weight"] = torch.randn(hidden, rank)
-
-    converted = convert_adapter(state, {"rank": rank, "alpha": rank})
-    patcher = comfy.model_patcher.ModelPatcher(
-        Root(), torch.device("cpu"), torch.device("cpu"))
-    terms = {module: [(a, b, scale)] for module, (a, b, scale) in converted.items()}
-
-    _validate_runtime_weight_targets(patcher, terms)
+def test_bypass_no_longer_requires_weight_function_capability(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    # Plain nn.Linear deliberately has no Comfy weight_function list. v1.5.0
+    # rejected this class because its bypass path depended on add_weight_wrapper;
+    # v1.5.1 must use the activation-side Comfy bypass contract instead.
+    base = _base_patcher()
+    converted, _, _ = _converted()
+    vdn = base.clone()
+    apply_adapters(vdn, converted, 1.0, mode="bypass", stage_path=None)
+    assert "vdn_lora" in vdn.injections
+    assert vdn.weight_wrapper_patches == {}

--- a/vdn_h3/apply.py
+++ b/vdn_h3/apply.py
@@ -1,35 +1,40 @@
 """Apply released VDN adapters through ComfyUI-owned patch mechanisms.
 
-VDN intentionally does *not* participate in ``BypassForwardHook`` chains. ``merge``
-uses normal ``ModelPatcher.add_patches`` weight ownership. ``bypass`` is retained as
-the low-VRAM runtime mode for workflow compatibility, but its implementation uses
-ComfyUI ``weight_function``/``add_weight_wrapper`` plus a managed additional model
-for the low-rank A/B tensors. VDN never traverses, replaces, splices or restores
-LoRA-target ``module.forward`` methods.
+``merge`` uses normal ``ModelPatcher.add_patches`` weight ownership.
+
+``bypass`` keeps the workflow-facing low-residency mode but deliberately uses
+ComfyUI's activation-side ``BypassForwardHook`` contract for ordinary LoRA
+targets. The hooks are installed through a stack-safe VDN injection that keeps
+VDN inside any independently managed Comfy bypass chain and can splice VDN back
+out without restoring stale ``module.forward`` objects.
+
+This is intentional for quantized MiniMax-H3 bases: using a ModelPatcher
+``weight_function`` on those layers forces Comfy's dequantized weight path. In
+the real stacked VDN + external runtime-DoRA workflow that v1.5.0 path regressed
+into a CUDA illegal-memory-access abort. The stack-safe hook path preserves the
+native quantized base forward and is the path previously validated with the same
+cross-provider Continuum lifecycle.
 
 Full-width AdaLN LoRAs on a curve/pruned H3 base are projected once through the
-exact pruning affine (basis + mean). Their weight term then targets the native
-small AdaLN coordinate projection and their essential constant term targets its
-float32 bias. No dense timestep MLP or AdaLN forward object patch is required.
+exact pruning affine (basis + mean). Their projected native curve weight and
+constant bias terms stay under ordinary Comfy weight-patch ownership even in
+``bypass`` mode; no dense timestep MLP reconstruction is used.
 """
 from __future__ import annotations
 
 import logging
-import uuid
 
 import torch
+import torch.nn.functional as F
 
-import comfy.float
 import comfy.lora
-import comfy.model_management
+import comfy.patcher_extension
 import comfy.utils
+import comfy.weight_adapter
 
 from vdn_h3.curve_affine import find_curve_affine, project_curve_terms
-from vdn_h3.managed import make_managed_runtime_lora_patcher
 
 _log = logging.getLogger("comfy.vdn")
-_RUNTIME_DELTA_BUFFER_BYTES = 8 << 20
-_RUNTIME_MODEL_KEY_PREFIX = "vdn_runtime_lora_"
 
 
 def _is_adaln(module: str) -> bool:
@@ -56,10 +61,9 @@ def _comfy_lora(converted):
     return lora
 
 
-def _native_patch_adapter(new_model, converted, strength: float) -> int:
-    """Register one adapter entirely through ``ModelPatcher.add_patches``."""
+def _load_comfy_adapter(new_model, converted):
     if not converted:
-        return 0
+        return {}, {}
     modules = sorted(converted)
     lora = _comfy_lora(converted)
     key_map = {module: f"diffusion_model.{module}.weight" for module in modules}
@@ -69,7 +73,8 @@ def _native_patch_adapter(new_model, converted, strength: float) -> int:
         raise RuntimeError(
             "VDN adapter targets are absent from the loaded MiniMax-H3 base: "
             + ", ".join(missing_base[:8])
-            + (" ..." if len(missing_base) > 8 else ""))
+            + (" ..." if len(missing_base) > 8 else "")
+        )
 
     loaded = comfy.lora.load_lora(lora, key_map, log_missing=False)
     expected = {key_map[m] for m in modules}
@@ -78,15 +83,27 @@ def _native_patch_adapter(new_model, converted, strength: float) -> int:
         raise RuntimeError(
             "ComfyUI could not materialize VDN LoRA targets: "
             + ", ".join(missing_loaded[:8])
-            + (" ..." if len(missing_loaded) > 8 else ""))
-    accepted = set(new_model.add_patches(
-        {key: loaded[key] for key in expected}, strength))
+            + (" ..." if len(missing_loaded) > 8 else "")
+        )
+    return loaded, key_map
+
+
+def _native_patch_adapter(new_model, converted, strength: float) -> int:
+    """Register one adapter entirely through ``ModelPatcher.add_patches``."""
+    if not converted:
+        return 0
+    loaded, key_map = _load_comfy_adapter(new_model, converted)
+    expected = set(key_map.values())
+    accepted = set(
+        new_model.add_patches({key: loaded[key] for key in expected}, strength)
+    )
     missing_patch = sorted(expected - accepted)
     if missing_patch:
         raise RuntimeError(
             "ModelPatcher rejected VDN adapter targets: "
             + ", ".join(missing_patch[:8])
-            + (" ..." if len(missing_patch) > 8 else ""))
+            + (" ..." if len(missing_patch) > 8 else "")
+        )
     return len(accepted)
 
 
@@ -96,9 +113,6 @@ def _native_patch_projected_curve(new_model, terms_by_module, bias_terms_by_modu
     bias_patches = 0
     state_keys = set(new_model.model.state_dict().keys())
 
-    # Keep projected weight updates low-rank and let Comfy own their normal LoRA
-    # materialization lifecycle. Multiple adapters can target the same module; each
-    # add_patches call appends rather than replacing the prior patch.
     for module in sorted(terms_by_module):
         for term in terms_by_module[module]:
             weight_patches += _native_patch_adapter(new_model, {module: term}, 1.0)
@@ -106,219 +120,312 @@ def _native_patch_projected_curve(new_model, terms_by_module, bias_terms_by_modu
     for module in sorted(bias_terms_by_module):
         key = f"diffusion_model.{module}.bias"
         if key not in state_keys:
-            raise RuntimeError(f"VDN projected AdaLN bias target is absent from the base: {key}")
+            raise RuntimeError(
+                f"VDN projected AdaLN bias target is absent from the base: {key}"
+            )
         base_bias = comfy.utils.get_attr(new_model.model, key)
         for offset, scale in bias_terms_by_module[module]:
             if tuple(offset.shape) != tuple(base_bias.shape):
                 raise RuntimeError(
                     f"VDN projected AdaLN bias {key} has {tuple(offset.shape)}, but "
-                    f"the base bias is {tuple(base_bias.shape)}")
+                    f"the base bias is {tuple(base_bias.shape)}"
+                )
             if scale == 0.0:
                 continue
             accepted = set(new_model.add_patches({key: (offset,)}, float(scale)))
             if key not in accepted:
-                raise RuntimeError(f"ModelPatcher rejected VDN projected AdaLN bias: {key}")
+                raise RuntimeError(
+                    f"ModelPatcher rejected VDN projected AdaLN bias: {key}"
+                )
             bias_patches += 1
     return weight_patches, bias_patches
 
 
-class _RuntimeLoRAWeight:
-    """Stateless runtime weight wrapper with bounded delta temporary memory."""
+class _FrugalLoRA(comfy.weight_adapter.LoRAAdapter):
+    """Activation-side LoRA used by VDN's stack-safe bypass path."""
 
-    __slots__ = ("key", "module", "source", "_vdn_runtime_lora")
+    def bypass_forward(self, org_forward, x, *args, **kwargs):
+        base_out = org_forward(x, *args, **kwargs)
+        if getattr(self, "is_conv", False):
+            return super().bypass_forward(org_forward, x, *args, **kwargs)
 
-    def __init__(self, key: str, module: str, source):
-        self.key = key
-        self.module = module
-        self.source = source
-        self._vdn_runtime_lora = True
-
-    @staticmethod
-    def _rows_per_chunk(out, input_dim):
-        row_bytes = max(1, int(input_dim) * out.element_size())
-        return max(1, _RUNTIME_DELTA_BUFFER_BYTES // row_bytes)
-
-    def __call__(self, weight):
-        if not isinstance(weight, torch.Tensor) or not weight.is_floating_point():
-            raise RuntimeError(
-                f"VDN runtime LoRA for {self.key} expected a floating compute weight; "
-                f"got {type(weight).__name__} / {getattr(weight, 'dtype', None)}")
-
-        compute_dtype = comfy.model_management.lora_compute_dtype(weight.device)
-        if compute_dtype is None:
-            compute_dtype = weight.dtype
-        out = weight.to(dtype=compute_dtype, copy=True)
-        terms = self.source.terms_on(self.module, out.device, compute_dtype)
-
-        for av, bv, scale in terms:
-            if scale == 0.0:
-                continue
-            rows_per_chunk = self._rows_per_chunk(out, av.shape[1])
-            for start in range(0, bv.shape[0], rows_per_chunk):
-                stop = min(start + rows_per_chunk, bv.shape[0])
-                delta = torch.mm(bv[start:stop], av)
-                if scale != 1.0:
-                    delta.mul_(scale)
-                out[start:stop].add_(delta)
-
-        if out.dtype != weight.dtype:
-            out = comfy.float.stochastic_rounding(
-                out, weight.dtype, seed=comfy.utils.string_to_seed(self.key))
-        return out
+        up, down, alpha = self.weights[0], self.weights[1], self.weights[2]
+        rank = down.shape[0]
+        scale = (
+            (alpha / rank if alpha is not None else 1.0)
+            * getattr(self, "multiplier", 1.0)
+        )
+        down = down.to(dtype=x.dtype)
+        up = up.to(dtype=x.dtype)
+        return base_out.add_(F.linear(F.linear(x, down), up), alpha=scale)
 
 
-class _RuntimeBiasWeight:
-    """Stateless runtime wrapper for projected pruned-AdaLN constant terms."""
+def _int8_fused_fc2(dm, modules):
+    """Return fc2 targets whose fused quantized forward bypasses module.forward.
 
-    __slots__ = ("key", "module", "source", "_vdn_runtime_bias")
-
-    def __init__(self, key: str, module: str, source):
-        self.key = key
-        self.module = module
-        self.source = source
-        self._vdn_runtime_bias = True
-
-    def __call__(self, bias):
-        if not isinstance(bias, torch.Tensor) or not bias.is_floating_point():
-            raise RuntimeError(
-                f"VDN runtime AdaLN bias for {self.key} expected a floating tensor; "
-                f"got {type(bias).__name__} / {getattr(bias, 'dtype', None)}")
-        compute_dtype = comfy.model_management.lora_compute_dtype(bias.device)
-        if compute_dtype is None:
-            compute_dtype = bias.dtype
-        out = bias.to(dtype=compute_dtype, copy=True)
-        for offset, scale in self.source.bias_terms_on(
-                self.module, out.device, compute_dtype):
-            if scale != 0.0:
-                out.add_(offset, alpha=float(scale))
-        if out.dtype != bias.dtype:
-            out = comfy.float.stochastic_rounding(
-                out, bias.dtype, seed=comfy.utils.string_to_seed(self.key))
-        return out
+    These targets cannot use an activation-side hook because H3's fused path reads
+    the underlying linear weight directly. Keep them under normal Comfy weight
+    patching, matching the previously validated PR #1 behavior.
+    """
+    fused = []
+    for module in modules:
+        if not module.endswith(".mlp.fc2"):
+            continue
+        try:
+            weight = comfy.utils.get_attr(dm, module + ".weight")
+        except Exception:
+            continue
+        if (
+            getattr(weight, "_layout_cls", None) == "TensorWiseINT8Layout"
+            and not getattr(getattr(weight, "_params", None), "transposed", False)
+        ):
+            fused.append(module)
+    return fused
 
 
-def _validate_runtime_weight_targets(new_model, terms_by_module):
-    state_keys = set(new_model.model.state_dict().keys())
-    for module in sorted(terms_by_module):
-        key = f"diffusion_model.{module}.weight"
-        if key not in state_keys:
-            raise RuntimeError(f"VDN runtime adapter target is absent from the base: {key}")
-
-        owner_key = f"diffusion_model.{module}"
-        owner = comfy.utils.get_attr(new_model.model, owner_key)
-        if not hasattr(owner, "weight_function"):
-            raise RuntimeError(
-                f"VDN runtime low-VRAM mode requires Comfy's weight_function contract, "
-                f"but {owner_key} ({type(owner).__name__}) does not expose it. Use "
-                "lora_mode='merge' for this unsupported module implementation.")
-
-        weight = comfy.utils.get_attr(new_model.model, key)
-        expected_shape = tuple(weight.shape)
-        for a, b, _scale in terms_by_module[module]:
-            if a.ndim != 2 or b.ndim != 2 or a.shape[0] != b.shape[1]:
-                raise RuntimeError(
-                    f"VDN runtime LoRA {key} has incompatible A{tuple(a.shape)} "
-                    f"B{tuple(b.shape)}")
-            delta_shape = (b.shape[0], a.shape[1])
-            if delta_shape != expected_shape:
-                raise RuntimeError(
-                    f"VDN runtime LoRA {key} produces {delta_shape}, but the base "
-                    f"weight is {expected_shape}")
-
-
-def _validate_runtime_bias_targets(new_model, terms_by_module):
-    state_keys = set(new_model.model.state_dict().keys())
-    for module in sorted(terms_by_module):
-        key = f"diffusion_model.{module}.bias"
-        if key not in state_keys:
-            raise RuntimeError(f"VDN runtime AdaLN bias target is absent from the base: {key}")
-        owner_key = f"diffusion_model.{module}"
-        owner = comfy.utils.get_attr(new_model.model, owner_key)
-        if not hasattr(owner, "bias_function"):
-            raise RuntimeError(
-                f"VDN runtime AdaLN bias requires Comfy's bias_function contract, but "
-                f"{owner_key} ({type(owner).__name__}) does not expose it")
-        bias = comfy.utils.get_attr(new_model.model, key)
-        for offset, _scale in terms_by_module[module]:
-            if tuple(offset.shape) != tuple(bias.shape):
-                raise RuntimeError(
-                    f"VDN runtime AdaLN bias {key} has {tuple(offset.shape)}, but "
-                    f"the base bias is {tuple(bias.shape)}")
-
-
-def _install_runtime_weight_adapters(new_model, terms_by_module, managed):
-    if not terms_by_module:
+def _bypass(new_model, converted, modules, strength, hooks):
+    if not modules:
         return 0
-    _validate_runtime_weight_targets(new_model, terms_by_module)
+    subset = {module: converted[module] for module in modules}
+    loaded, key_map = _load_comfy_adapter(new_model, subset)
+
+    manager = comfy.weight_adapter.BypassInjectionManager()
     installed = 0
-    for module in sorted(terms_by_module):
-        key = f"diffusion_model.{module}.weight"
-        new_model.add_weight_wrapper(key, _RuntimeLoRAWeight(key, module, managed))
+    for module in modules:
+        key = key_map[module]
+        adapter = loaded.get(key)
+        if adapter is None:
+            continue
+        if isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
+            adapter = _FrugalLoRA(adapter.loaded_keys, adapter.weights)
+        elif not isinstance(adapter, comfy.weight_adapter.WeightAdapterBase):
+            raise RuntimeError(
+                f"VDN bypass target {key} produced unsupported adapter "
+                f"{type(adapter).__name__}"
+            )
+        manager.add_adapter(key, adapter, strength=float(strength))
         installed += 1
+
+    manager.create_injections(new_model.model)
+    hooks.extend(manager.hooks)
+    if len(manager.hooks) != installed:
+        raise RuntimeError(
+            f"VDN bypass created {len(manager.hooks)} hooks for {installed} adapters"
+        )
     return installed
 
 
-def _install_runtime_bias_adapters(new_model, terms_by_module, managed):
-    if not terms_by_module:
-        return 0
-    _validate_runtime_bias_targets(new_model, terms_by_module)
-    installed = 0
-    for module in sorted(terms_by_module):
-        key = f"diffusion_model.{module}.bias"
-        new_model.add_weight_wrapper(key, _RuntimeBiasWeight(key, module, managed))
-        installed += 1
-    return installed
+def _same_bound_method(left, right):
+    """Identity check stable across repeated bound-method attribute reads."""
+    if left is right:
+        return True
+    left_self = getattr(left, "__self__", None)
+    right_self = getattr(right, "__self__", None)
+    left_func = getattr(left, "__func__", None)
+    right_func = getattr(right, "__func__", None)
+    return (
+        left_self is right_self
+        and left_func is not None
+        and left_func is right_func
+    )
 
 
-def _merge_runtime_terms(*groups):
-    combined = {}
-    for group in groups:
-        for module, terms in group.items():
-            combined.setdefault(module, []).extend(terms)
-    return combined
+def _bypass_hook_owner(forward):
+    """Return the Comfy bypass hook owning a bound forward, if there is one."""
+    hook_type = getattr(comfy.weight_adapter, "BypassForwardHook", None)
+    owner = getattr(forward, "__self__", None)
+    if isinstance(hook_type, type) and isinstance(owner, hook_type):
+        return owner
+    return None
 
 
-def apply_adapters(new_model, converted_by_name, strength, mode="merge",
-                   stage_path=None, verbose=False):
-    """Apply released adapters through merge or safe runtime-low-VRAM mode."""
+def _inject_hook_stack_safe(hook):
+    """Inject VDN below any already-active Comfy bypass-hook chain."""
+    if getattr(hook, "original_forward", None) is not None:
+        return
+
+    module = hook.module
+    previous_forward = module.forward
+    hook.inject()  # lets Comfy set adapter metadata/device placement
+
+    outer = _bypass_hook_owner(previous_forward)
+    if outer is None:
+        return
+
+    current = outer
+    seen = set()
+    while True:
+        marker = id(current)
+        if marker in seen:
+            module.forward = previous_forward
+            hook.original_forward = None
+            raise RuntimeError("VDN found a cyclic Comfy bypass-forward chain")
+        seen.add(marker)
+
+        inner_forward = getattr(current, "original_forward", None)
+        inner = _bypass_hook_owner(inner_forward)
+        if inner is None:
+            break
+        current = inner
+
+    # hook.inject() temporarily made VDN outermost. Restore the existing chain,
+    # then splice VDN immediately above its true/base forward instead.
+    module.forward = previous_forward
+    hook.original_forward = inner_forward
+    current.original_forward = hook._bypass_forward
+
+
+def _eject_hook_stack_safe(hook):
+    """Remove a VDN hook even when another Comfy bypass hook still wraps it."""
+    original_forward = getattr(hook, "original_forward", None)
+    if original_forward is None:
+        return
+
+    module = hook.module
+    target = hook._bypass_forward
+    current_forward = module.forward
+
+    if _same_bound_method(current_forward, target):
+        module.forward = original_forward
+        hook.original_forward = None
+        return
+
+    current = _bypass_hook_owner(current_forward)
+    seen = set()
+    while current is not None:
+        marker = id(current)
+        if marker in seen:
+            raise RuntimeError(
+                "VDN found a cyclic Comfy bypass-forward chain during eject"
+            )
+        seen.add(marker)
+
+        inner_forward = getattr(current, "original_forward", None)
+        if _same_bound_method(inner_forward, target):
+            current.original_forward = original_forward
+            hook.original_forward = None
+            return
+        current = _bypass_hook_owner(inner_forward)
+
+    # Another provider may already have detached this hook. Never resurrect a
+    # stale original over the currently valid live chain.
+    hook.original_forward = None
+
+
+def _install_injection(new_model, hooks):
+    """Install one clone- and cross-provider-safe VDN bypass injection."""
+    if not hooks:
+        return
+
+    owner = new_model.model  # clone-shared inner model
+
+    def inject_all(model_patcher):
+        old = getattr(owner, "_vdn_live_hooks", None)
+        if old:
+            for hook in reversed(old):
+                _eject_hook_stack_safe(hook)
+        try:
+            for hook in hooks:
+                _inject_hook_stack_safe(hook)
+        except Exception:
+            for hook in reversed(hooks):
+                _eject_hook_stack_safe(hook)
+            raise
+        owner._vdn_live_hooks = hooks
+
+    def eject_all(model_patcher):
+        for hook in reversed(hooks):
+            _eject_hook_stack_safe(hook)
+        if getattr(owner, "_vdn_live_hooks", None) is hooks:
+            owner._vdn_live_hooks = None
+
+    injection = comfy.patcher_extension.PatcherInjection(
+        inject=inject_all,
+        eject=eject_all,
+    )
+    new_model.set_injections("vdn_lora", [injection])
+
+
+def apply_adapters(
+    new_model,
+    converted_by_name,
+    strength,
+    mode="merge",
+    stage_path=None,
+    verbose=False,
+):
+    """Apply released VDN adapters through merge or stack-safe bypass mode."""
     if mode not in ("merge", "bypass"):
-        raise ValueError(f"VDN lora_mode must be 'merge' or 'bypass', got {mode!r}")
+        raise ValueError(
+            f"VDN lora_mode must be 'merge' or 'bypass', got {mode!r}"
+        )
 
     per_name = strength if isinstance(strength, dict) else None
     dm = new_model.get_model_object("diffusion_model")
     pruned = _is_pruned_base(dm)
     report = {}
     curve_terms = {}
-    runtime_terms = {}
+    all_hooks = []
 
     for name, converted in converted_by_name.items():
         s = float(per_name.get(name, 1.0) if per_name is not None else strength)
         ordinary = {}
-        runtime_count = 0
         curve_count = 0
         for path, (a, b, scale) in converted.items():
             effective_scale = float(scale) * s
             if pruned and _is_adaln(path):
                 curve_terms.setdefault(path, []).append((a, b, effective_scale))
                 curve_count += 1
-            elif mode == "bypass":
-                runtime_terms.setdefault(path, []).append((a, b, effective_scale))
-                runtime_count += 1
             else:
                 ordinary[path] = (a, b, scale)
 
-        patched = _native_patch_adapter(new_model, ordinary, s) if ordinary else 0
+        native_patches = 0
+        bypass_targets = 0
+        fused_native_targets = 0
+
+        if mode == "merge":
+            native_patches = (
+                _native_patch_adapter(new_model, ordinary, s) if ordinary else 0
+            )
+        elif ordinary:
+            modules = sorted(ordinary)
+            fused = set(_int8_fused_fc2(dm, modules))
+            bypass_modules = [module for module in modules if module not in fused]
+            fused_terms = {module: ordinary[module] for module in sorted(fused)}
+
+            bypass_targets = _bypass(
+                new_model,
+                ordinary,
+                bypass_modules,
+                s,
+                all_hooks,
+            )
+            if fused_terms:
+                fused_native_targets = _native_patch_adapter(
+                    new_model, fused_terms, s
+                )
+                native_patches += fused_native_targets
+
         report[name] = {
-            "native_weight_patches": patched,
-            "runtime_weight_targets": runtime_count,
+            "native_weight_patches": native_patches,
+            "runtime_bypass_targets": bypass_targets,
+            # Kept for one release as a compatibility/logging alias. It no longer
+            # means ModelPatcher weight wrappers in v1.5.1.
+            "runtime_weight_targets": bypass_targets,
+            "fused_native_targets": fused_native_targets,
             "curve_adaln": curve_count,
             "strength": s,
         }
         if verbose:
             _log.info(
-                "[vdn] adapter %s: %d native patches, %d runtime-lowvram targets, "
-                "%d curve AdaLN",
-                name, patched, runtime_count, curve_count)
+                "[vdn] adapter %s: %d native patches, %d stack-safe bypass targets, "
+                "%d fused-native targets, %d curve AdaLN",
+                name,
+                native_patches,
+                bypass_targets,
+                fused_native_targets,
+                curve_count,
+            )
 
     projected_curve = {}
     curve_bias_terms = {}
@@ -329,73 +436,66 @@ def apply_adapters(new_model, converted_by_name, strength, mode="merge",
         table = getattr(dm, "adaln_t_table", None)
         if table is None:
             raise RuntimeError(
-                "MiniMax-H3 was detected as a curve/pruned base but has no adaln_t_table")
-        if getattr(table, "device", None) is not None and table.device.type == "meta":
+                "MiniMax-H3 was detected as a curve/pruned base but has no "
+                "adaln_t_table"
+            )
+        if (
+            getattr(table, "device", None) is not None
+            and table.device.type == "meta"
+        ):
             raise RuntimeError(
-                "MiniMax-H3 adaln_t_table is still on the meta device; load the base "
-                "checkpoint before applying VDN")
+                "MiniMax-H3 adaln_t_table is still on the meta device; load the "
+                "base checkpoint before applying VDN"
+            )
         affine = find_curve_affine(stage_path, table, base_patcher=new_model)
-        projected_curve, curve_bias_terms = project_curve_terms(curve_terms, affine)
+        projected_curve, curve_bias_terms = project_curve_terms(
+            curve_terms, affine
+        )
         _log.info(
             "[vdn] curve AdaLN affine: %s (%d weight targets + %d float32 bias targets)",
-            affine.source, len(projected_curve), len(curve_bias_terms))
+            affine.source,
+            len(projected_curve),
+            len(curve_bias_terms),
+        )
 
-    if mode == "merge" and projected_curve:
+    curve_weight_patches = 0
+    curve_bias_patches = 0
+    if projected_curve or curve_bias_terms:
         curve_weight_patches, curve_bias_patches = _native_patch_projected_curve(
-            new_model, projected_curve, curve_bias_terms)
+            new_model,
+            projected_curve,
+            curve_bias_terms,
+        )
+
+    if mode == "bypass":
+        _install_injection(new_model, all_hooks)
+        runtime_report = {
+            "mode": "stack_safe_bypass",
+            "forward_hooks": len(all_hooks),
+            "weight_wrappers": 0,
+            "bias_wrappers": 0,
+            "managed_adapter_bytes": 0,
+            "delta_buffer_limit_bytes": 0,
+            "owner_key": None,
+            "stack_safe_cross_provider": True,
+            "projected_curve_weight_patches": curve_weight_patches,
+            "projected_curve_bias_patches": curve_bias_patches,
+        }
+        report["runtime_bypass"] = runtime_report
+        # Preserve the v1.5.0 report key for callers/log parsers while making the
+        # changed ownership explicit in its values.
+        report["runtime_lowvram"] = runtime_report
+
+    if affine is not None:
         report["curve_adaln_projection"] = {
             "source": affine.source,
-            "mode": "merge",
+            "mode": (
+                "merge" if mode == "merge" else "bypass_native_projected_patch"
+            ),
             "weight_patches": curve_weight_patches,
             "bias_patches": curve_bias_patches,
             "dense_width": int(affine.mean.shape[0]),
             "curve_width": int(affine.basis.shape[0]),
         }
-        return report
 
-    if projected_curve:
-        runtime_terms = _merge_runtime_terms(runtime_terms, projected_curve)
-
-    managed = None
-    managed_bytes = 0
-    runtime_owner_key = None
-    if runtime_terms or curve_bias_terms:
-        managed, managed_patcher = make_managed_runtime_lora_patcher(
-            runtime_terms, new_model, bias_terms_by_module=curve_bias_terms)
-        # Core currently does not compare weight_wrapper_patches in
-        # ModelPatcher.clone_has_same_weights(), and it can return early when both
-        # patchers have no ordinary weight patches. Give every Apply execution a
-        # distinct additional-model key so changing strength/options cannot reuse a
-        # still-loaded wrapper set from an older clone. Clones of *this* result keep
-        # the same key and remain equivalent.
-        runtime_owner_key = _RUNTIME_MODEL_KEY_PREFIX + uuid.uuid4().hex
-        new_model.set_additional_models(runtime_owner_key, [managed_patcher])
-        managed_bytes = sum(
-            p.numel() * p.element_size() for p in managed.parameters())
-
-    runtime_wrappers = _install_runtime_weight_adapters(
-        new_model, runtime_terms, managed) if runtime_terms else 0
-    runtime_bias_wrappers = _install_runtime_bias_adapters(
-        new_model, curve_bias_terms, managed) if curve_bias_terms else 0
-    if runtime_wrappers or runtime_bias_wrappers:
-        report["runtime_lowvram"] = {
-            "weight_wrappers": runtime_wrappers,
-            "bias_wrappers": runtime_bias_wrappers,
-            "forward_hooks": 0,
-            "managed_adapter_bytes": managed_bytes,
-            "delta_buffer_limit_bytes": _RUNTIME_DELTA_BUFFER_BYTES,
-            "owner_key": runtime_owner_key,
-        }
-
-    if affine is not None:
-        report["curve_adaln_projection"] = {
-            "source": affine.source,
-            "mode": "bypass",
-            "weight_targets": len(projected_curve),
-            "bias_targets": len(curve_bias_terms),
-            "dense_width": int(affine.mean.shape[0]),
-            "curve_width": int(affine.basis.shape[0]),
-            "managed_adapter_bytes": managed_bytes,
-            "owner_key": runtime_owner_key,
-        }
     return report

--- a/vdn_h3/nodes.py
+++ b/vdn_h3/nodes.py
@@ -83,9 +83,6 @@ def _effective_free_vram(model):
         loaded_size = int(model.loaded_size())
         remaining = max(0, model_size - loaded_size)
     except Exception as exc:
-        # Current and pinned Comfy expose both methods. If an older/custom patcher
-        # does not, do not invent a model-size estimate; explicit stream/off remains
-        # available and the current compatibility smoke will catch core API drift.
         _log.warning(
             "[vdn] could not reserve unloaded MODEL bytes for auto VRAM policy (%s); "
             "using raw free-memory reading", exc)
@@ -103,8 +100,6 @@ def _apply_vdn(model, vdn_checkpoint, strength, lora_mode, branch_weights,
     if lora_mode not in ("merge", "bypass"):
         raise ValueError(f"lora_mode must be merge or bypass, got {lora_mode!r}")
     if branch_weights == "cache_gpu":
-        # Serialized v1.3/v1.4 workflows used this name. The safe equivalent is a
-        # Comfy-owned resident additional model, not VDN's former private GPU cache.
         _log.warning("[vdn] branch_weights=cache_gpu is deprecated; using resident")
         branch_weights = "resident"
     if branch_weights not in ("auto", "stream", "resident"):
@@ -269,9 +264,10 @@ class ApplyVDNH3:
                 "tooltip": "Adapter strength. 1.0 is the released checkpoint setting."}),
             "lora_mode": (["merge", "bypass"], {
                 "default": "merge",
-                "tooltip": "merge uses normal Comfy weight patches. bypass is the "
-                           "low-VRAM runtime mode: Comfy weight_function wrappers apply "
-                           "the LoRA per layer without VDN touching module.forward."}),
+                "tooltip": "merge uses normal Comfy weight patches. bypass uses "
+                           "stack-safe Comfy BypassForwardHook adapters for ordinary "
+                           "targets, preserving native quantized forwards while safely "
+                           "stacking with other runtime bypass providers."}),
             "branch_weights": (["auto", "stream", "resident"], {
                 "default": "auto",
                 "tooltip": "auto: resident BF16 when the base-reserved VRAM budget "
@@ -323,8 +319,9 @@ class ApplyVDNH3Advanced:
                 "default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
             "lora_mode": (["merge", "bypass"], {
                 "default": "merge",
-                "tooltip": "bypass uses the safe runtime low-VRAM weight-wrapper path; "
-                           "it does not install forward hooks/chains."}),
+                "tooltip": "bypass uses VDN's stack-safe Comfy bypass-hook lifecycle "
+                           "for ordinary LoRA targets; projected curve AdaLN remains "
+                           "under normal native weight/bias patches."}),
             "branch_weights": (["auto", "stream", "resident"], {"default": "auto"}),
             "retain_buffers": (["auto", "on", "off"], {"default": "auto"}),
             "verbose": ("BOOLEAN", {"default": False}),


### PR DESCRIPTION
## Summary

v1.5.1 fixes a production regression introduced by v1.5.0's `lora_mode=bypass` implementation.

v1.5.0 moved VDN's ordinary LoRA bypass execution from Comfy activation-side bypass hooks to `ModelPatcher.add_weight_wrapper()` / `weight_function`. On quantized MiniMax-H3, that changes the layer onto Comfy's copied/dequantized compute-weight path. In the real RTX PRO 6000 stack using INT8 ConvRot H3 + VDN bypass + an independent runtime-bypass DoRA/LoRA provider + `cudaMallocAsync` + Flow Mixed-Grid/Continuum/Spectrum, the first actual H3 evaluation hard-aborted with a CUDA illegal-memory-access error.

CUDA errors are asynchronously reported, so the visible `F.linear` frame cannot by itself identify the exact originating kernel. The regression boundary is nevertheless concrete: the v1.5.0 runtime weight-wrapper topology was new, while the earlier stack-safe VDN bypass-hook architecture had already been validated in the same multi-provider lifecycle.

## Fix

This hotfix restores the production-validated PR #1 lifecycle **inside the current v1.5 architecture** rather than reverting v1.5 wholesale.

For ordinary VDN LoRA targets in `lora_mode=bypass`:

- use Comfy `BypassForwardHook` objects;
- install all VDN hooks through one stack-safe `PatcherInjection`;
- insert VDN below an already-active independent Comfy bypass chain regardless of provider registration order;
- splice VDN out of the live chain without restoring stale `module.forward` objects;
- replace an older live VDN hook set on the clone-shared inner model before injecting a new one;
- roll back partial injection on failure;
- fail closed if the existing Comfy bypass chain is already cyclic;
- keep fused INT8 `mlp.fc2` targets that bypass `module.forward` on normal Comfy weight patches.

The active bypass path now explicitly reports:

- `mode=stack_safe_bypass`
- `weight_wrappers=0`
- `bias_wrappers=0`
- `managed_adapter_bytes=0`
- `stack_safe_cross_provider=true`

The v1.5.0 runtime `weight_function`/`add_weight_wrapper` path is no longer installed by bypass mode.

## Pruned / curve AdaLN

The v1.5 exact pruning-affine work is retained.

Released full-width AdaLN LoRAs are still projected through the resolved `adaln_basis` + `adaln_mean` pair, including the required constant bias term. In v1.5.1 the already-native projected curve weight and bias terms use ordinary `ModelPatcher.add_patches()` ownership in both adapter modes; they do not use VDN activation hooks and do not use the superseded v1.5.0 runtime weight wrappers.

## What is not reverted

The hotfix keeps the rest of v1.5 intact:

- external mixed-sequence API 2 / `mixed_grid_low_suffix` for Flow-Aligned Regenerate;
- API 1 target-sparse compatibility;
- pruned/curve H3 support;
- branch `auto|stream|resident` lifecycle;
- execution-owned retained buffers and bounded prefetch;
- upstream v1.4.3 `cudaMallocAsync` `record_stream` handling;
- current Comfy compiler guard;
- legacy `ApplyVDNH3Advanced` positional-widget migration.

## Regression coverage

The updated suite covers:

- repeated multi-hook VDN injection/ejection cycles;
- VDN-first and external-provider-first ordering;
- same-order provider teardown in both orders;
- replacement of a live VDN hook while an external provider remains active;
- cyclic bypass-chain rejection;
- bypass on a custom/quantized-like module without installing `weight_function` wrappers;
- repeated clone/load/unload cycles without accumulation;
- exact projected curve AdaLN math through native patches;
- merge mode remaining on normal weight patches.

The first staging CI exposed exactly two stale v1.5 tests that still required the removed weight-wrapper topology; those assertions were replaced with regressions for the restored stack-safe bypass contract.

## Release/docs

- version bumped to **1.5.1**;
- README updated to describe the actual active bypass architecture and v1.5.0 regression;
- release notes added;
- Benchmarks/current-runtime documentation corrected;
- upstream reconciliation documentation corrected.

## Topology

- base: `1fc9d0d979683e3410587fac17358d3dd583e551`
- head: `841044740bf8c9149db332475acabc11327ddf68`
- tree: `ed5cb9d7e717743b9b383cf022775347fd6079d7`
- exactly **1 commit ahead / 0 behind**

This remains draft until the exact final-head CI is green.