### PR TITLE
Mirror: validate v1.5.2 runtime adapter introspection

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -1,25 +1,30 @@
 # Benchmarks — ComfyUI-VDN-H3
 
-This file preserves historical measurements and defines the measurement contract for the current runtime. **Historical numbers are not performance validation of v1.5.1.**
+This file preserves historical measurements and defines the measurement contract for the current runtime. **Historical numbers are not performance validation of v1.5.2.**
 
-## Current v1.5.1 execution differences
+## Current v1.5.2 candidate execution differences
 
 Compared with the older measurements below:
 
-- `lora_mode=bypass` uses stack-safe activation-side Comfy `BypassForwardHook` adapters for ordinary LoRA targets;
-- the v1.5.0 `add_weight_wrapper()` / `weight_function` adapter path is no longer active;
-- VDN can coexist with another ordinary Comfy runtime-bypass provider on the same module by inserting underneath the existing chain and splicing itself out safely;
+- `lora_mode=bypass` uses one VDN-owned PyTorch forward post-hook per affected module;
+- VDN never replaces or splices `module.forward`, so another Comfy runtime-bypass provider retains independent ownership of its forward chain;
+- the v1.5.0 `add_weight_wrapper()` / `weight_function` adapter path is not active;
+- the v1.5.1 VDN `BypassForwardHook` linked-list/splicing path is not active;
+- all VDN LoRA terms for one module are combined into one exact low-rank residual;
+- runtime adapter factors are staged onto the intended compute device at injection time, before the first H3 forward;
+- projected pruned/curve AdaLN updates stay off the base weight/bias in bypass mode and are applied as an exact projected post-forward residual plus constant bias;
 - fused INT8 `mlp.fc2` targets that do not call `module.forward` remain ordinary Comfy weight patches;
-- full-width curve/pruned AdaLN adapters are projected through the exact pruning affine and applied as native curve weight + bias patches;
-- the old private GPU branch cache is replaced by bounded streaming or a Comfy-managed additional `ModelPatcher`;
-- selected upstream v1.4 performance work is retained under state-owned lifecycle rules: VRAM-aware branch selection, native INT8 ConvRot streaming under pressure, execution-leased retained scratch, and one-block streaming prefetch;
+- merge-mode curve/pruned AdaLN adapters are projected through the exact pruning affine and applied as native curve weight + bias patches;
+- the old private GPU branch cache remains replaced by bounded streaming or a Comfy-managed additional `ModelPatcher`;
+- selected upstream v1.4 performance work remains under state-owned lifecycle rules: VRAM-aware branch selection, native INT8 ConvRot streaming under pressure, execution-leased retained scratch, and one-block streaming prefetch;
+- cross-stream prefetched branch tensors record the model consumer stream under both native and `cudaMallocAsync` allocators;
 - `auto` placement reserves still-unloaded base-model bytes before assigning VDN residency.
 
-New matched GPU measurements are required before assigning speed or VRAM numbers to v1.5.1.
+New matched GPU measurements are required before assigning speed or VRAM numbers to v1.5.2. The complete stacked RTX PRO 6000 workflow is also a correctness release gate, not merely a benchmark.
 
 ## Historical RTX 5090 measurements
 
-These measurements predate the v1.5/v1.5.1 lifecycle work.
+These measurements predate the v1.5-v1.5.2 lifecycle work.
 
 ### Rig
 
@@ -58,11 +63,15 @@ Normal Comfy `ModelPatcher.add_patches()` application. This is the conservative 
 
 ### `lora_mode=bypass`
 
-Ordinary adapter targets keep the resident base parameter untouched and add their low-rank activation delta through Comfy's bypass-hook mechanism. VDN's injection layer is specifically regression-tested with an independent external runtime-bypass provider in both provider insertion orders and across repeated load/unload cycles.
+Ordinary adapter targets keep the resident base parameter untouched. VDN registers a standard PyTorch forward post-hook and adds the exact low-rank residual after the module returns. VDN does not replace `module.forward`, does not enter another provider's `BypassForwardHook` chain, and does not install a Comfy `weight_function` wrapper.
 
-This path preserves the native base forward for quantized/custom layers instead of installing the v1.5.0 `weight_function` wrapper. That distinction matters because a Comfy weight function on quantized H3 can force a copied/dequantized compute-weight path.
+The production history matters for interpreting this candidate:
 
-The production reason for the v1.5.1 hotfix was a hard CUDA illegal-address abort in the stacked INT8 ConvRot H3 + VDN bypass + external runtime-DoRA + `cudaMallocAsync` workflow after v1.5.0 introduced runtime weight wrappers. CUDA failure reporting is asynchronous, so that trace does not prove which kernel originally faulted, but the v1.5.0 wrapper path was the new regression boundary and is no longer used.
+- v1.5.0 weight wrappers failed the stacked INT8 ConvRot H3 + external runtime-DoRA + `cudaMallocAsync` workflow;
+- v1.5.1 removed those wrappers but its VDN mutable-forward chain also failed;
+- the first v1.5.2 post-hook candidate still materialized projected curve-AdaLN patches and lazily copied runtime factors in the first hook; the complete real run still failed at the first actual H3 evaluation.
+
+The revised v1.5.2 candidate removes both remaining VDN-side boundaries: curve-AdaLN stays non-materialized in bypass mode, and runtime factors are staged before the model forward begins. CUDA reporting is asynchronous, so none of these historical Python stack locations are treated as proof of a particular originating CUDA kernel.
 
 ## Curve/pruned AdaLN projection
 
@@ -79,9 +88,7 @@ A_pruned   = A @ basis.T
 bias_delta = B @ (A @ mean)
 ```
 
-The constant term is required. v1.5.1 registers the projected native curve weight and bias terms as ordinary Comfy patches in both adapter modes; there is no reconstructed dense timestep MLP and no runtime weight wrapper for these terms.
-
-The affine resolver accepts only the exact pruning basis/mean corresponding to the loaded curve table. A mismatched or unverifiable affine fails closed.
+The constant term is required. In bypass mode the projected low-rank term and constant are applied after `adaln_proj.linear` without modifying its base parameters. In merge mode they remain ordinary Comfy weight/bias patches. The affine resolver accepts only the exact pruning basis/mean corresponding to the loaded curve table; a mismatched or unverifiable affine fails closed.
 
 ## Branch residency
 
@@ -98,7 +105,8 @@ The affine resolver accepts only the exact pruning basis/mean corresponding to t
 
 - resolves branch tensors block-by-block;
 - keeps safetensors mappings bounded to each resolution operation;
-- when retained buffers are enabled on CUDA, uses one-block lookahead prefetch keyed by block/device/dtype.
+- when retained buffers are enabled on CUDA, uses one-block lookahead prefetch keyed by block/device/dtype;
+- waits on the producer event and records the consumer stream on the returned storages before use.
 
 ### `branch_weights=resident`
 
@@ -110,8 +118,6 @@ The affine resolver accepts only the exact pruning basis/mean corresponding to t
 
 `retain_buffers=auto|on|off` controls VDN scratch, not model weights. Retained mode can reuse bounded recurrence, grouped-window, activation-copy and prefetch scratch owned by one `VDNState`. One execution leases the pool; nested/concurrent execution falls back to isolated transient storage.
 
-Under `cudaMallocAsync`, explicit `record_stream` bookkeeping is skipped because the allocator is already stream ordered.
-
 ## Current CI validation
 
 CI validates implementation contracts rather than performance:
@@ -122,11 +128,14 @@ CI validates implementation contracts rather than performance:
 - adapter conversion and checkpoint/model-spec validation;
 - curve/pruned affine projection including the constant bias term;
 - merge-path custom/quantized weight lifecycle tests;
-- stack-safe bypass lifecycle tests across independent providers and repeated cycles;
+- non-mutating post-forward bypass lifecycle tests across independent providers and repeated cycles;
+- projected curve-AdaLN bypass identity without base weight/bias mutation;
 - explicit assertions that active bypass installs no `weight_wrapper_patches`;
+- injection-time runtime-factor staging contract;
+- cross-stream branch-prefetch ownership including quantized backing tensors;
 - retained-vs-transient branch/window numerical identity;
 - resource lease/isolation and prefetch placement tests;
 - current ComfyUI-main import/registration smoke;
 - legacy `ApplyVDNH3Advanced` positional-workflow migration.
 
-Real decoded-media output and GPU timing remain separate release evidence, not something inferred from CPU CI.
+Real decoded-media output, full GPU workflow completion, VRAM, and timing remain separate release evidence, not something inferred from CPU CI.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Official stages include:
 | `vdn_checkpoint` | Stage directory under `models/vdn/` |
 | `apply_turbo_adapter` | Apply the released Turbo/DMD adapter when the stage provides it |
 | `strength` | Adapter strength; `1.0` is the released setting |
-| `lora_mode` | `merge` or stack-safe runtime `bypass` |
+| `lora_mode` | `merge` or isolated runtime `bypass` |
 | `branch_weights` | `auto`, `stream`, or `resident` |
 | `retain_buffers` | `auto`, `on`, or `off` |
 | `attention_backend` | `grouped` or opt-in `flex` |
@@ -53,31 +53,23 @@ Adds independent Stage-B/Turbo strengths, optional compiled helpers, and explici
 
 ### `lora_mode=merge`
 
-Uses ordinary Comfy `ModelPatcher.add_patches()` weight ownership. This remains the conservative reference path for matched output validation.
+Uses ordinary Comfy `ModelPatcher.add_patches()` weight ownership. This is the conservative reference path for matched output validation.
 
 ### `lora_mode=bypass`
 
-v1.5.1 uses Comfy's activation-side `BypassForwardHook` mechanism for ordinary VDN LoRA targets, with an additional VDN lifecycle layer that makes independently owned runtime adapter providers safe to stack.
+The v1.5.2 candidate keeps ordinary VDN LoRA terms off both Comfy weight wrappers and mutable `module.forward` bypass chains. Each affected module receives one VDN-owned PyTorch **forward post-hook**. The normal module forward executes first, including any independently managed provider that chooses to wrap it, and VDN then adds its exact low-rank residual to the returned tensor.
 
-The important properties are:
+The runtime contract is:
 
-- VDN does not assume it is the only runtime-bypass provider on a module;
-- if another Comfy bypass hook is already active, VDN inserts underneath it rather than blindly becoming the outermost owner;
-- teardown can splice VDN out of the middle of the live chain without restoring a stale `module.forward`;
-- the same logic works whether VDN or the external provider was registered first;
-- rerunning Apply VDN replaces the previous live VDN hook set on the clone-shared inner model instead of accumulating another adapter delta;
-- pre-existing cyclic bypass chains fail closed;
-- fused INT8 `mlp.fc2` targets that do not call `module.forward` stay on normal Comfy weight patches.
-
-### Why v1.5.1 changed bypass again
-
-v1.5.0 temporarily implemented bypass with `ModelPatcher.add_weight_wrapper()` / `weight_function` and a managed A/B-factor model. On quantized H3, a weight function changes execution onto Comfy's copied/dequantized compute-weight path.
-
-A production RTX PRO 6000 run combining the INT8 ConvRot H3 base, VDN bypass, a second runtime-bypass DoRA/LoRA provider, `cudaMallocAsync`, Flow Mixed-Grid, Continuum and Spectrum/SA-PECE hard-aborted on the first actual H3 evaluation with a CUDA illegal memory access. The fatal stack was inside the external Comfy bypass-LoRA chain. Because CUDA reporting is asynchronous, the stack does not by itself identify the exact originating kernel, but the v1.5.0 weight-wrapper execution path was the new regression boundary.
-
-The older stack-safe activation-hook implementation had already been validated with the same cross-provider lifecycle, so v1.5.1 restores that proven execution architecture rather than trying to patch around the quantized weight-wrapper interaction.
-
-The v1.5.0 wrapper path is **not** installed by `lora_mode=bypass` in v1.5.1.
+- VDN never replaces, splices, saves, or restores `module.forward`;
+- VDN does not install `ModelPatcher.add_weight_wrapper()` / `weight_function` callbacks;
+- all active VDN terms for one module are combined into one exact low-rank residual;
+- adapter factors are staged onto the intended compute device when the VDN `PatcherInjection` is injected, before the first H3 forward;
+- post-hook handles are generation-owned on the clone-shared inner model;
+- applying a newer VDN clone replaces the previous VDN registration instead of accumulating deltas;
+- ejecting an older/stale clone cannot remove the newer registration;
+- another provider using Comfy `BypassForwardHook` remains outside VDN's ownership and its forward chain is never rewritten by VDN;
+- fused INT8 `mlp.fc2` targets whose H3 fast path bypasses `module.forward` remain ordinary Comfy weight patches.
 
 ## Pruned / curve MiniMax-H3 bases
 
@@ -96,7 +88,12 @@ bias_delta = B @ (A @ mean)
 
 Both terms are required. VDN must resolve the matching `adaln_basis` + `adaln_mean` pair and fails closed rather than guessing or dropping incompatible AdaLN updates.
 
-In v1.5.1, the projected curve weight and constant bias terms use ordinary Comfy weight/bias patches in both adapter modes. They do not use the activation-side VDN hooks and do not use the superseded v1.5.0 weight-wrapper path.
+Ownership depends on adapter mode:
+
+- `merge`: projected curve weight and constant bias use ordinary Comfy weight/bias patches;
+- `bypass`: the exact projected low-rank residual plus constant bias are added by a post-forward hook on `adaln_proj.linear`; the pruned base weight and bias remain untouched.
+
+This distinction matters on quantized/pruned H3. Earlier v1.5.x candidates that materialized the projected AdaLN terms in bypass mode were part of the remaining VDN-specific execution preceding the production CUDA failure boundary. The bypass path now avoids that base-weight mutation entirely.
 
 If a matching BF16 source checkpoint remains beside an INT8 derivative, VDN can read only the small affine tensors from it. Otherwise use:
 
@@ -116,7 +113,11 @@ python tools/extract_h3_adaln_affine.py \
 
 `retain_buffers=on` reuses execution-owned scan/window/activation scratch. The retained pool belongs to one VDN state and is leased for one diffusion-model execution; nested/concurrent runs that cannot acquire it use isolated transient scratch.
 
-Under `cudaMallocAsync`, explicit `record_stream` bookkeeping is skipped because the allocator is already stream ordered. This incorporates upstream v1.4.3's torch-warning fix in this fork's state-owned prefetch implementation.
+### CUDA stream ownership
+
+One-block branch prefetch copies weights on a dedicated CUDA producer stream and consumes them on the model stream. VDN records that consumer stream for every prefetched tensor and for the backing tensors of quantized branch weights under **both** the native allocator and `cudaMallocAsync`.
+
+This intentionally differs from a blanket “skip `record_stream` under `cudaMallocAsync`” rule. PyTorch's async allocator still tracks non-creation usage streams before `cudaFreeAsync`; only redundant same-stream recording is unnecessary.
 
 ## Flow-Aligned Regenerate interoperability
 
@@ -148,23 +149,27 @@ Newly created nodes still default to `architecture_mode="checkpoint"`.
 
 - `grouped` is the portable attention backend and remains the default. `flex` is opt-in and falls back to grouped if unavailable.
 - VDN owns the H3 attention object patch. Another extension that tries to own the same `diffusion_model.blocks.*.attn.forward` target is rejected rather than ambiguously stacked.
-- Runtime LoRA/DoRA providers using Comfy's ordinary `BypassForwardHook` mechanism may coexist with VDN bypass; the cross-provider chain is regression-tested in both insertion orders.
+- Runtime LoRA/DoRA providers using Comfy's ordinary `BypassForwardHook` mechanism may coexist with VDN bypass. VDN does not join or rewrite that provider's forward chain.
 - The AIMDO malloc-graph compatibility guard is scoped only around VDN diffusion-model execution and restores the user's compiler setting afterward.
 - Historical benchmark numbers in [Benchmarks.md](Benchmarks.md) predate the current lifecycle work and are not assigned to this runtime without matched measurement.
 
 ## Validation
 
-v1.5.1 adds explicit regression coverage for:
+The v1.5.2 candidate has explicit regression coverage for:
 
-- repeated VDN hook injection/ejection;
-- VDN-first and external-provider-first stacked bypass providers;
-- live VDN replacement while an external runtime provider stays active;
-- cyclic-chain rejection;
-- zero `weight_wrapper_patches` in the active bypass path;
-- projected pruned-AdaLN math through native patches;
+- exact ordinary post-forward LoRA math while `module.forward` remains externally owned;
+- exact projected curve-AdaLN bypass math while the base curve weight/bias remain unchanged;
+- VDN-first and external-provider-first coexistence with a real Comfy `BypassForwardHook`;
+- VDN removal while the external provider remains live;
+- clone-shared VDN replacement and stale-clone eject without accumulation;
+- repeated pseudo-Continuum injection/ejection;
+- injection-time adapter-factor staging;
+- zero `weight_wrapper_patches` and zero VDN mutable-forward wrappers in active bypass mode;
+- custom/quantized-like modules retaining their native weight path;
+- cross-stream prefetch lifetime ownership under native and `cudaMallocAsync` allocators;
 - current ComfyUI import/registration and the existing OpenVDN numerical/oracle suite.
 
-The API-2 mixed-grid path remains the VDN contract used by the production Flow-Aligned Regenerate Continuum workflow.
+CPU/oracle CI validates numerical and ownership contracts. The complete stacked RTX PRO 6000 workflow remains the release acceptance gate for v1.5.2; this branch must not be merged or released on CPU CI alone.
 
 ## Upstream and licensing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,63 @@
+# ComfyUI-VDN-H3 v1.5.2
+
+v1.5.2 is still under release validation. It replaces VDN's mutable-forward runtime bypass and, after the first post-hook candidate still failed the real stacked RTX PRO 6000 workflow, removes two additional VDN-side lifetime/materialization hazards exposed by that trace.
+
+## Runtime-bypass ownership
+
+- Ordinary VDN LoRA residuals use PyTorch forward **post-hooks**.
+- VDN does **not** replace, splice, save, or restore `module.forward`.
+- VDN does **not** use `ModelPatcher.weight_function` / `add_weight_wrapper`.
+- One post-hook is registered per affected module, with all VDN terms fused into one exact low-rank residual for that module.
+- Registration handles are generation-owned across clone-shared models: a newer VDN clone replaces the old registration, while stale ejects cannot remove the newer generation.
+- Independently managed Comfy `BypassForwardHook` providers remain outside VDN's ownership; VDN never enters their mutable forward chain.
+- Fused INT8 `mlp.fc2` targets retain native Comfy patch ownership because the H3 fused path bypasses `module.forward`.
+
+## Revised pruned-AdaLN bypass
+
+The first v1.5.2 candidate still materialized the exact projected curve-AdaLN update as native weight+bias patches in bypass mode. The full production run still aborted at the first actual H3 evaluation. CUDA reported the error when the first ordinary VDN post-hook attempted a device copy, but CUDA errors are asynchronous and MiniMax-H3 runs `adaln_proj` before the attention projection.
+
+The revised candidate keeps the exact projection while removing that base-weight mutation:
+
+```text
+dense(t) ≈ mean + curve(t) @ basis
+A_pruned   = A @ basis.T
+bias_delta = B @ (A @ mean)
+```
+
+- In `bypass`, the projected low-rank curve-coordinate residual and constant bias are added by a post-forward hook on `adaln_proj.linear`.
+- The pruned base AdaLN weight and bias remain untouched.
+- In `merge`, the exact projected weight+bias terms continue to use ordinary native Comfy patches.
+
+## Adapter staging
+
+The first candidate lazily copied VDN adapter factors from CPU to GPU in the first post-hook invocation. That made the first `.to()` call a convenient asynchronous CUDA error-reporting boundary even if the actual fault occurred earlier.
+
+The revised candidate stages all runtime VDN adapter factors synchronously onto the intended compute device **when the PatcherInjection is injected**, before any H3 module forward executes. No ordinary VDN post-hook performs its normal H2D setup during the first model call. An unexpected device/dtype change still has a synchronous correctness fallback.
+
+## cudaMallocAsync prefetch lifetime
+
+VDN's one-block branch prefetch uses a producer CUDA stream and hands the resulting tensors to the model's consumer stream. The fork previously inherited upstream v1.4.3's blanket `record_stream` suppression under `cudaMallocAsync`.
+
+That is too broad for cross-stream handoff. PyTorch's `CUDAMallocAsyncAllocator` tracks recorded side-usage streams and synchronizes them before `cudaFreeAsync`. v1.5.2 therefore records the consumer stream for every prefetched tensor and its quantized backing storages under both native and `cudaMallocAsync` allocators.
+
+## Validation status
+
+CPU/oracle coverage includes:
+
+- exact ordinary post-forward LoRA math with `module.forward` unchanged;
+- exact projected curve-AdaLN bypass math with base weight/bias unchanged;
+- coexistence with a real Comfy `BypassForwardHook` on ordinary and curve targets;
+- clone-shared replacement and stale-generation ejection;
+- repeated pseudo-Continuum injection/ejection cycles;
+- custom/quantized-like modules retaining their native weight path;
+- zero VDN weight wrappers and zero VDN mutable-forward wrappers in bypass mode;
+- injection-time runtime-factor staging;
+- cross-stream prefetch `record_stream` ownership including `cudaMallocAsync` and quantized backing tensors;
+- merge mode remaining on normal weight patches;
+- current-Comfy import smoke and official OpenVDN numerical/oracle coverage.
+
+**Release remains blocked until the complete real RTX PRO 6000 production workflow finishes cleanly.**
+
 # ComfyUI-VDN-H3 v1.5.1
 
 v1.5.1 is a hotfix for a production regression introduced by v1.5.0's `lora_mode=bypass` implementation.
@@ -14,50 +74,13 @@ In the production RTX PRO 6000 workflow using:
 - `cudaMallocAsync`;
 - Continuum + Flow Mixed-Grid + Spectrum/SA-PECE;
 
-the first actual H3 evaluation hard-aborted with `CUDA error: an illegal memory access was encountered`. The fatal Python stack was inside the external Comfy `BypassForwardHook`/LoRA `F.linear` chain. CUDA errors are asynchronous, so that stack alone does not identify the exact originating kernel, but the regression boundary is the v1.5.0 weight-wrapper path: the previously tested stack-safe VDN bypass-hook implementation worked in the same multi-provider lifecycle.
+the first actual H3 evaluation hard-aborted with `CUDA error: an illegal memory access was encountered`. The fatal Python stack was inside the external Comfy `BypassForwardHook`/LoRA `F.linear` chain. CUDA errors are asynchronous, so that stack alone does not identify the exact originating kernel.
 
-v1.5.1 therefore restores that validated architecture for ordinary VDN LoRA targets instead of trying another private weight-wrapper variant.
-
-### Bypass ownership in v1.5.1
-
-- Ordinary VDN LoRA targets use Comfy's normal `BypassForwardHook` objects.
-- VDN installs them through one stack-safe `PatcherInjection`.
-- VDN is spliced **inside** an already-active Comfy bypass chain regardless of provider insertion order.
-- VDN can remove itself from the middle of that live chain without restoring stale `module.forward` references.
-- Reapplying VDN on a clone-shared inner model first removes the previous live VDN hook set, preventing accumulated deltas across reruns.
-- Cyclic pre-existing bypass chains fail closed.
-- Fused INT8 `mlp.fc2` targets that bypass `module.forward` remain normal Comfy weight patches.
-- The v1.5.0 runtime `weight_function`/`add_weight_wrapper` path is no longer installed by `lora_mode=bypass`.
-
-This is the same cross-provider lifetime design that was previously validated in the superseded PR #1; PR #1 itself remains closed because v1.5.1 integrates that lifecycle into the newer v1.5 architecture rather than reverting the rest of v1.5.
+v1.5.1 restored the older VDN `BypassForwardHook` architecture, including stack-safe linked-list insertion/removal. A later production run showed that this was not sufficient: the same stacked workflow still aborted. v1.5.1 is therefore superseded by the v1.5.2 work above.
 
 ## Pruned / curve AdaLN behavior
 
-The v1.5 exact pruning-affine work is retained.
-
-Full-width released AdaLN LoRAs are still projected through the resolved `adaln_basis` + `adaln_mean` pair:
-
-```text
-A_pruned   = A @ basis.T
-bias_delta = B @ (A @ mean)
-```
-
-In bypass mode, these already-native projected curve weight/bias terms now use ordinary Comfy `ModelPatcher.add_patches()` ownership. They do not use VDN forward hooks and do not use the v1.5.0 weight-wrapper path.
-
-## Regression coverage
-
-The v1.5.1 suite explicitly covers:
-
-- repeated multi-hook VDN inject/eject cycles;
-- VDN-first and external-provider-first injection ordering;
-- same-order provider teardown in both orders;
-- replacement of a live VDN hook set while an external bypass hook remains active;
-- cyclic-chain fail-closed behavior;
-- `apply_adapters(..., mode="bypass")` creating a VDN injection with **zero weight wrappers**;
-- bypass operation on a plain linear module with no `weight_function` contract;
-- projected curve AdaLN math through native weight/bias patches.
-
-All v1.5.0 work unrelated to the regressed adapter execution mechanism remains: VDN API 2 mixed-grid support, pruned/curve AdaLN projection, branch placement and retained-buffer lifecycle, `cudaMallocAsync` prefetch handling, current Comfy smoke tests, and the legacy `ApplyVDNH3Advanced` widget migration.
+The v1.5 exact pruning-affine work was retained. Full-width released AdaLN LoRAs were projected through the resolved `adaln_basis` + `adaln_mean` pair. v1.5.1 materialized those projected curve weight/bias terms as ordinary Comfy patches in both adapter modes; the revised v1.5.2 bypass path no longer does so.
 
 ---
 
@@ -65,4 +88,4 @@ All v1.5.0 work unrelated to the regressed adapter execution mechanism remains: 
 
 v1.5.0 was the correctness/lifecycle and Flow-interoperability release of the xmarre fork. It added the mixed-grid API used by MiniMax-H3 Flow-Aligned Regenerate, current pruned/INT8 MiniMax-H3 support, exact curve-AdaLN projection, branch/runtime lifecycle hardening, upstream v1.4.3 reconciliation, and backwards-compatible Advanced-node workflow migration.
 
-Its `lora_mode=bypass` weight-wrapper implementation is superseded by v1.5.1 because of the stacked runtime-adapter regression described above. `merge` behavior was not implicated.
+Its `lora_mode=bypass` weight-wrapper implementation is superseded because of the stacked runtime-adapter regression described above. `merge` behavior was not implicated.

--- a/docs/UPSTREAM_RECONCILIATION.md
+++ b/docs/UPSTREAM_RECONCILIATION.md
@@ -15,8 +15,9 @@ This fork keeps the released VDN-H3 architecture and tracks the original ComfyUI
 - one-block stream lookahead;
 - reusable scan/window/activation scratch;
 - grouped/Flex attention runtime improvements;
-- the AIMDO malloc-graph compatibility workaround;
-- v1.4.3's `cudaMallocAsync` rule: explicit `record_stream` is skipped when the allocator is already stream ordered.
+- the AIMDO malloc-graph compatibility workaround.
+
+The v1.4.3 allocator warning suppression is **not** copied literally anymore. Upstream skips every `record_stream` call when the allocator backend is `cudaMallocAsync`. That is correct only when recording the allocation/creation stream itself. VDN's branch prefetch is a different case: weights are allocated on a dedicated prefetch stream and consumed on the model stream. PyTorch's `CUDAMallocAsyncAllocator` explicitly keeps a set of `recorded_streams` and synchronizes those side-usage streams before `cudaFreeAsync`. The fork therefore always records the consumer stream for prefetched tensors, including their quantized backing storages, under both native and `cudaMallocAsync` allocators.
 
 ## State ownership differences
 
@@ -30,29 +31,50 @@ The fork does not retain process-global model-weight ownership:
 - nested/concurrent execution that cannot acquire the retained pool receives isolated transient scratch;
 - one-block prefetch uses a single bounded tensor-less executor and at most one state-owned future/result;
 - completed prefetch results cannot be overwritten before `take()` consumes them;
+- cross-stream prefetch ownership is recorded on the consumer stream before the producer-owned tensors can be released;
 - Flex BlockMask caching is bounded and keyed by device/layout identity.
 
-## Adapter lifecycle: v1.5.1
+## Adapter lifecycle: v1.5.2 candidate
 
 `merge` remains normal `ModelPatcher.add_patches()` ownership.
 
-For ordinary LoRA targets, `lora_mode=bypass` uses Comfy `BypassForwardHook` objects but **not** the unsafe plain provider lifecycle. VDN wraps those hooks in a stack-safe `PatcherInjection` derived from the production-validated PR #1 fix:
+For ordinary LoRA targets, `lora_mode=bypass` uses VDN-owned PyTorch forward post-hooks. VDN intentionally does not use either of the two adapter-execution topologies that failed the real stacked quantized workflow:
 
-- VDN is inserted inside an already-active independent Comfy bypass chain;
-- VDN can be spliced out while another provider remains active;
-- both provider insertion orders are supported;
-- clone-shared reruns replace the old live VDN hook set instead of accumulating deltas;
-- cyclic existing chains fail closed;
+- no `weight_function` / `add_weight_wrapper` execution from v1.5.0;
+- no VDN `BypassForwardHook` linked list or custom `module.forward` splicing from v1.5.1.
+
+Instead:
+
+- the existing module forward executes normally;
+- any independently managed runtime provider keeps sole ownership of whatever forward wrapper chain it installs;
+- VDN adds its exact low-rank residual from a PyTorch post-hook after that call returns;
+- all VDN terms for one module are combined into one post-hook residual;
+- adapter factors are moved to the intended compute device synchronously at injection time, before the first H3 forward;
+- one generation-owned `PatcherInjection` registers/removes the handles;
+- a newer clone-shared VDN generation replaces the older registration;
+- stale older ejects cannot remove the newer generation;
 - fused INT8 `mlp.fc2` targets that bypass `module.forward` remain ordinary weight patches.
 
-v1.5.0 temporarily replaced this with `weight_function` / `add_weight_wrapper` runtime LoRA execution. That path forced quantized H3 layers through Comfy's dequantized compute-weight route and regressed the real stacked VDN + external runtime-DoRA workflow into a CUDA illegal-memory-access abort. v1.5.1 removes that active execution path.
+### Pruned / curve AdaLN
 
-Full-width released AdaLN LoRAs on supported pruned/curve H3 bases are still projected through the exact pruning affine, including the required constant bias term. The already-native projected curve weight/bias terms use normal Comfy patches in both adapter modes.
+The exact pruning affine is still used:
+
+```text
+dense(t) ≈ mean + curve(t) @ basis
+A_pruned   = A @ basis.T
+bias_delta = B @ (A @ mean)
+```
+
+The first v1.5.2 candidate projected those terms correctly but then registered the projected curve weight and constant bias as ordinary native patches even in bypass mode. The real RTX PRO 6000 run invalidated that candidate: the first actual H3 evaluation still hit `cudaErrorIllegalAddress`, asynchronously reported when the first ordinary VDN post-hook attempted its lazy device copy. MiniMax-H3 evaluates `adaln_proj` before the attention projection, so the materialized VDN curve patch was the remaining VDN-specific adapter operation preceding that reporting boundary.
+
+The revised candidate therefore keeps the exact projected AdaLN update out of the base parameter tree in `bypass` mode as well. The projected low-rank curve-coordinate residual plus its constant bias are added by a post-forward hook on `adaln_proj.linear`; the underlying pruned weight and bias remain untouched. `merge` mode continues to use native projected weight/bias patches.
+
+This isolates bypass mode from all three VDN-side base-weight/forward mutations implicated by the production traces: runtime weight wrappers, mutable forward chains, and projected curve-AdaLN materialization.
 
 ## Flow-Aligned external sequence
 
-This fork additionally defines API 2 for `mixed_grid_low_suffix`, used by `xmarre/MiniMax-H3-Flow-Aligned-Regenerate`. It keeps the learned dense gate active on the mixed sequence while disabling only geometry-dependent local/linear-complement processing. API 1 target-sparse compatibility remains accepted.
+This fork additionally defines API 2 for `mixed_grid_low_suffix`, used by `xmarre/MiniMax-H3-Flow-Aligned-Regenerate`. It keeps the learned dense softmax gate active on the mixed sequence while disabling only geometry-dependent local/linear-complement processing. API 1 target-sparse compatibility remains accepted.
 
-## v1.4.3 allocator change
+## Release gate
 
-Upstream commit `b49130c26a70d12c542601c5bc4f7ee0f112ee2e` skips `record_stream` under `cudaMallocAsync`. This fork applies the same allocator condition in `vdn_h3.runtime._StreamPrefetcher`, where this branch owns its asynchronous prefetch lifecycle. Dedicated regression coverage remains in place.
+The revised v1.5.2 implementation remains a candidate until the complete production RTX PRO 6000 workflow finishes without the CUDA abort. CPU/oracle CI proves numerical and ownership contracts, not GPU allocator/kernel safety.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-vdn-h3"
-version = "1.5.1"
+version = "1.5.2"
 description = "VDN-H3 hybrid attention for ComfyUI's native MiniMax-H3 model"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_bypass_reinject.py
+++ b/tests/test_bypass_reinject.py
@@ -1,210 +1,215 @@
-"""Regression tests for VDN bypass-hook reinjection and cross-provider teardown.
+"""Lifecycle regressions for VDN's non-mutating runtime bypass.
 
-ComfyUI's ModelPatcher can have several independently owned bypass injections on
-one module. Plain BypassForwardHook teardown is only safe under a global LIFO
-order, so VDN keeps its hooks inside the external chain and splices them out
-safely regardless of provider insertion/ejection order.
-
-These are the lifecycle invariants from the previously production-validated PR #1
-path. v1.5.1 restores this architecture after the v1.5.0 weight-wrapper path
-regressed a stacked VDN + runtime-DoRA quantized workflow.
+VDN must never replace ``module.forward``. Its low-residency LoRA residuals use
+PyTorch forward post-hooks whose handles are owned by one PatcherInjection.
+ModelPatcher clones share the inner model, so a new VDN generation replaces the
+old registered handles and stale clone ejection cannot remove the newer set.
 """
 from __future__ import annotations
-
-import types
 
 import torch
 import torch.nn as nn
 
 import comfy.model_management
-import comfy.patcher_extension
+import comfy.model_patcher
 from comfy.weight_adapter.bypass import BypassForwardHook
+from comfy.weight_adapter.lora import LoRAAdapter
 
-from vdn_h3.apply import _FrugalLoRA, _install_injection
-
-
-def _adapter():
-    up = torch.randn(8, 4)
-    down = torch.randn(4, 8) * 0.1
-    return _FrugalLoRA(set(), (up, down, torch.tensor(4.0)))
+from vdn_h3.apply import apply_adapters
 
 
-class _Patcher:
-    def __init__(self, model=None):
-        self.injections = {}
-        self.model = model if model is not None else types.SimpleNamespace()
-
-    def set_injections(self, key, value):
-        self.injections[key] = value
-
-    def inject_model(self):
-        for injections in self.injections.values():
-            for injection in injections:
-                injection.inject(self)
-
-    def eject_model(self):
-        # Deliberately mirrors the hazardous same-order provider teardown that the
-        # VDN splicing logic must survive.
-        for injections in self.injections.values():
-            for injection in injections:
-                injection.eject(self)
+class Diffusion(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8, bias=False)
+        self.use_adaln_curves = False
 
 
-def _fresh_module():
-    torch.manual_seed(0)
-    mod = nn.Linear(8, 8)
-    return mod, mod.forward
+class Root(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.diffusion_model = Diffusion()
+        self.device = torch.device("cpu")
 
 
-def _adapter_lora(hook, x):
-    up, down, _ = hook.adapter.weights
-    return torch.nn.functional.linear(
+def _base():
+    torch.manual_seed(901)
+    return comfy.model_patcher.ModelPatcher(
+        Root(), torch.device("cpu"), torch.device("cpu")
+    )
+
+
+def _term(seed, rank=3):
+    gen = torch.Generator().manual_seed(seed)
+    down = torch.randn(rank, 8, generator=gen)
+    up = torch.randn(8, rank, generator=gen)
+    return down, up
+
+
+def _apply(base, down, up, strength=1.0):
+    patcher = base.clone()
+    report = apply_adapters(
+        patcher,
+        {"default": {"linear": (down, up, 1.0)}},
+        strength,
+        mode="bypass",
+        stage_path=None,
+    )
+    return patcher, report
+
+
+def _delta(x, down, up, strength=1.0):
+    return strength * torch.nn.functional.linear(
         torch.nn.functional.linear(x, down), up
     )
 
 
-def _external_injection(hook):
-    return comfy.patcher_extension.PatcherInjection(
-        inject=lambda _patcher: hook.inject(),
-        eject=lambda _patcher: hook.eject(),
-    )
-
-
-def test_vdn_multiple_hooks_repeated_cycles_restore_true_forward(monkeypatch):
+def test_vdn_bypass_never_replaces_module_forward(monkeypatch):
     monkeypatch.setattr(
         comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
     )
-    mod, true_fwd = _fresh_module()
-    hook_d = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    hook_t = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    patcher = _Patcher()
-    _install_injection(patcher, [hook_d, hook_t])
-    injection = patcher.injections["vdn_lora"][0]
+    base = _base()
+    module = base.model.diffusion_model.linear
+    true_forward = module.forward
+    down, up = _term(902)
+    vdn, report = _apply(base, down, up, 0.75)
+    injection = vdn.injections["vdn_lora"][0]
+    x = torch.randn(4, 8)
+    want = true_forward(x) + _delta(x, down, up, 0.75)
 
+    assert report["runtime_bypass"]["mode"] == "post_forward_hook_bypass"
+    assert report["runtime_bypass"]["mutable_forward_wrappers"] == 0
+    assert report["runtime_bypass"]["module_forward_untouched"] is True
+    assert module.forward == true_forward
+
+    injection.inject(vdn)
+    try:
+        assert module.forward == true_forward
+        assert torch.allclose(module(x), want, atol=1e-5, rtol=1e-5)
+    finally:
+        injection.eject(vdn)
+    assert module.forward == true_forward
+
+
+def test_clone_replacement_and_stale_eject_do_not_accumulate(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    base = _base()
+    module = base.model.diffusion_model.linear
+    true_forward = module.forward
+    down1, up1 = _term(903)
+    down2, up2 = _term(904)
+    first, _ = _apply(base, down1, up1, 1.0)
+    second, _ = _apply(base, down2, up2, 0.5)
+    inj1 = first.injections["vdn_lora"][0]
+    inj2 = second.injections["vdn_lora"][0]
     x = torch.randn(3, 8)
-    want = true_fwd(x) + _adapter_lora(hook_d, x) + _adapter_lora(hook_t, x)
 
-    for cycle in range(5):
-        injection.inject(patcher)
-        assert mod.forward == hook_d._bypass_forward, cycle
-        assert hook_d.original_forward == hook_t._bypass_forward, cycle
-        assert hook_t.original_forward == true_fwd, cycle
-        assert torch.allclose(mod(x), want, atol=1e-5), cycle
+    inj1.inject(first)
+    assert module.forward == true_forward
+    assert torch.allclose(
+        module(x), true_forward(x) + _delta(x, down1, up1), atol=1e-5
+    )
 
-        injection.eject(patcher)
-        assert mod.forward == true_fwd, cycle
-        assert hook_d.original_forward is None
-        assert hook_t.original_forward is None
+    # Same shared model, newer clone: this must replace, not stack.
+    inj2.inject(second)
+    want2 = true_forward(x) + _delta(x, down2, up2, 0.5)
+    assert module.forward == true_forward
+    assert torch.allclose(module(x), want2, atol=1e-5)
+
+    # Ejecting the stale generation must not tear down the current one.
+    inj1.eject(first)
+    assert module.forward == true_forward
+    assert torch.allclose(module(x), want2, atol=1e-5)
+
+    inj2.eject(second)
+    assert module.forward == true_forward
+    assert torch.allclose(module(x), true_forward(x), atol=1e-6)
 
 
-def _run_cross_provider_cycles(monkeypatch, vdn_first):
+def _external_hook(module, down, up, strength=1.0):
+    # Core Comfy LoRA bypass hook: this deliberately DOES mutate module.forward.
+    # VDN must coexist without becoming part of this linked list.
+    alpha = torch.tensor(float(down.shape[0]))
+    adapter = LoRAAdapter(set(), (up, down, alpha, None, None, None))
+    return BypassForwardHook(module, adapter, multiplier=float(strength))
+
+
+def _run_cross_provider(monkeypatch, external_first):
     monkeypatch.setattr(
         comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
     )
-    mod, true_fwd = _fresh_module()
-    vdn_hook = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    external_hook = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    patcher = _Patcher()
-
-    if vdn_first:
-        _install_injection(patcher, [vdn_hook])
-        patcher.set_injections(
-            "external_runtime_lora", [_external_injection(external_hook)]
-        )
-    else:
-        patcher.set_injections(
-            "external_runtime_lora", [_external_injection(external_hook)]
-        )
-        _install_injection(patcher, [vdn_hook])
-
-    x = torch.randn(3, 8)
-    want = (
-        true_fwd(x)
-        + _adapter_lora(vdn_hook, x)
-        + _adapter_lora(external_hook, x)
-    )
-
-    for cycle in range(5):
-        patcher.inject_model()
-
-        # External provider is outermost in both insertion orders; VDN is safely
-        # spliced underneath it and above the true base forward.
-        assert mod.forward == external_hook._bypass_forward, cycle
-        assert external_hook.original_forward == vdn_hook._bypass_forward, cycle
-        assert vdn_hook.original_forward == true_fwd, cycle
-        assert torch.allclose(mod(x), want, atol=1e-5), cycle
-
-        patcher.eject_model()
-        assert mod.forward == true_fwd, cycle
-        assert vdn_hook.original_forward is None
-        assert external_hook.original_forward is None
-
-
-def test_cross_provider_forward_order_eject_vdn_first(monkeypatch):
-    _run_cross_provider_cycles(monkeypatch, vdn_first=True)
-
-
-def test_cross_provider_forward_order_eject_external_first(monkeypatch):
-    _run_cross_provider_cycles(monkeypatch, vdn_first=False)
-
-
-def test_live_vdn_replacement_under_external_hook(monkeypatch):
-    monkeypatch.setattr(
-        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
-    )
-    mod, true_fwd = _fresh_module()
-    shared_owner = types.SimpleNamespace()
-    first = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    second = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    external = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-
-    patcher1 = _Patcher(shared_owner)
-    _install_injection(patcher1, [first])
-    inj1 = patcher1.injections["vdn_lora"][0]
-    inj1.inject(patcher1)
-    external.inject()
-
-    assert mod.forward == external._bypass_forward
-    assert external.original_forward == first._bypass_forward
-
-    patcher2 = _Patcher(shared_owner)
-    _install_injection(patcher2, [second])
-    inj2 = patcher2.injections["vdn_lora"][0]
-    inj2.inject(patcher2)
-
-    assert first.original_forward is None
-    assert mod.forward == external._bypass_forward
-    assert external.original_forward == second._bypass_forward
-    assert second.original_forward == true_fwd
-
+    base = _base()
+    module = base.model.diffusion_model.linear
+    true_forward = module.forward
+    vd, vu = _term(905)
+    ed, eu = _term(906)
+    vdn, _ = _apply(base, vd, vu, 0.6)
+    injection = vdn.injections["vdn_lora"][0]
+    external = _external_hook(module, ed, eu, 0.4)
     x = torch.randn(2, 8)
-    want = true_fwd(x) + _adapter_lora(second, x) + _adapter_lora(external, x)
-    assert torch.allclose(mod(x), want, atol=1e-5)
-
-    inj2.eject(patcher2)
-    assert mod.forward == external._bypass_forward
-    assert external.original_forward == true_fwd
-    external.eject()
-    assert mod.forward == true_fwd
-
-
-def test_cycle_detection_fails_closed(monkeypatch):
-    monkeypatch.setattr(
-        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    want = (
+        true_forward(x)
+        + _delta(x, ed, eu, 0.4)
+        + _delta(x, vd, vu, 0.6)
     )
-    mod, _ = _fresh_module()
-    external = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    external.inject()
-    external.original_forward = external._bypass_forward
 
-    vdn = BypassForwardHook(mod, _adapter(), multiplier=1.0)
-    patcher = _Patcher()
-    _install_injection(patcher, [vdn])
-    injection = patcher.injections["vdn_lora"][0]
+    if external_first:
+        external.inject()
+        external_forward = module.forward
+        injection.inject(vdn)
+    else:
+        injection.inject(vdn)
+        assert module.forward == true_forward
+        external.inject()
+        external_forward = module.forward
 
     try:
-        injection.inject(patcher)
-    except RuntimeError as exc:
-        assert "cyclic Comfy bypass-forward chain" in str(exc)
-    else:
-        raise AssertionError("cyclic bypass chain was accepted")
+        # VDN registration never changes the external provider's forward object.
+        assert module.forward == external_forward
+        assert torch.allclose(module(x), want, atol=1e-5, rtol=1e-5)
+
+        injection.eject(vdn)
+        # External provider is still live and exact after VDN removal.
+        assert module.forward == external_forward
+        external_only = true_forward(x) + _delta(x, ed, eu, 0.4)
+        assert torch.allclose(module(x), external_only, atol=1e-5, rtol=1e-5)
+    finally:
+        # idempotent VDN stale eject is harmless
+        injection.eject(vdn)
+        external.eject()
+
+    assert module.forward == true_forward
+
+
+def test_cross_provider_external_first(monkeypatch):
+    _run_cross_provider(monkeypatch, external_first=True)
+
+
+def test_cross_provider_vdn_first(monkeypatch):
+    _run_cross_provider(monkeypatch, external_first=False)
+
+
+def test_repeated_pseudo_continuum_chunks_do_not_accumulate(monkeypatch):
+    monkeypatch.setattr(
+        comfy.model_management, "get_torch_device", lambda: torch.device("cpu")
+    )
+    base = _base()
+    module = base.model.diffusion_model.linear
+    true_forward = module.forward
+    down, up = _term(907)
+    x = torch.randn(3, 8)
+    want = true_forward(x) + _delta(x, down, up)
+
+    for chunk in range(12):
+        vdn, _ = _apply(base, down, up, 1.0)
+        injection = vdn.injections["vdn_lora"][0]
+        injection.inject(vdn)
+        try:
+            assert module.forward == true_forward, chunk
+            assert torch.allclose(module(x), want, atol=1e-5), chunk
+        finally:
+            injection.eject(vdn)
+        assert module.forward == true_forward, chunk
+        assert torch.allclose(module(x), true_forward(x), atol=1e-6), chunk

--- a/tests/test_cuda_allocator_guard.py
+++ b/tests/test_cuda_allocator_guard.py
@@ -1,43 +1,75 @@
 from __future__ import annotations
 
+import torch
+
 from vdn_h3 import runtime
 
 
-def _reset():
-    runtime._RECORD_STREAM_NEEDED = None
+class _Recorded:
+    def __init__(self):
+        self.streams = []
+
+    def record_stream(self, stream):
+        self.streams.append(stream)
 
 
-def test_record_stream_skipped_for_cuda_malloc_async(monkeypatch):
-    _reset()
-    monkeypatch.setattr(runtime.torch.cuda, "get_allocator_backend", lambda: "cudaMallocAsync")
-    assert runtime._record_stream_needed() is False
-    # Cached decision must not re-query or change mid-run.
-    monkeypatch.setattr(runtime.torch.cuda, "get_allocator_backend", lambda: "native")
-    assert runtime._record_stream_needed() is False
+def test_prefetch_records_consumer_stream_without_allocator_special_case():
+    stream = object()
+    tensor = _Recorded()
+
+    runtime._StreamPrefetcher._record_stream(tensor, stream)
+
+    assert tensor.streams == [stream]
 
 
-def test_record_stream_retained_for_native_allocator(monkeypatch):
-    _reset()
-    monkeypatch.setattr(runtime.torch.cuda, "get_allocator_backend", lambda: "native")
-    assert runtime._record_stream_needed() is True
+def test_prefetch_records_consumer_stream_even_when_cuda_malloc_async(monkeypatch):
+    """cudaMallocAsync still tracks non-creation usage streams in PyTorch.
+
+    The prefetch producer stream and model consumer stream are different, so VDN must
+    record the consumer regardless of allocator backend. This test deliberately makes
+    the allocator query return cudaMallocAsync; _record_stream must not branch on it.
+    """
+    monkeypatch.setattr(
+        runtime.torch.cuda,
+        "get_allocator_backend",
+        lambda: "cudaMallocAsync",
+        raising=False,
+    )
+    stream = object()
+    tensor = _Recorded()
+
+    runtime._StreamPrefetcher._record_stream(tensor, stream)
+
+    assert tensor.streams == [stream]
 
 
-def test_record_stream_query_failure_fails_conservative(monkeypatch):
-    _reset()
+def test_prefetch_records_quantized_backing_storages(monkeypatch):
+    stream = object()
+    calls = []
 
-    def fail():
-        raise RuntimeError("allocator API unavailable")
+    def record_tensor(self, got_stream):
+        calls.append((id(self), got_stream))
 
-    monkeypatch.setattr(runtime.torch.cuda, "get_allocator_backend", fail)
-    assert runtime._record_stream_needed() is True
+    monkeypatch.setattr(torch.Tensor, "record_stream", record_tensor, raising=True)
 
+    class Params:
+        pass
 
-def test_prefetch_record_stream_is_noop_under_cuda_malloc_async(monkeypatch):
-    _reset()
-    monkeypatch.setattr(runtime.torch.cuda, "get_allocator_backend", lambda: "cudaMallocAsync")
+    wrapper = _Recorded()
+    wrapper._qdata = torch.empty(1)
+    wrapper._params = Params()
+    wrapper._params.scale = torch.empty(1)
+    wrapper._params.orig_weight = torch.empty(1)
+    wrapper._params.bias = torch.empty(1)
 
-    class FakeTensor:
-        def record_stream(self, stream):
-            raise AssertionError("record_stream must not be called under cudaMallocAsync")
+    expected_children = {
+        id(wrapper._qdata),
+        id(wrapper._params.scale),
+        id(wrapper._params.orig_weight),
+        id(wrapper._params.bias),
+    }
 
-    runtime._StreamPrefetcher._record_stream(FakeTensor(), object())
+    runtime._StreamPrefetcher._record_stream(wrapper, stream)
+
+    assert wrapper.streams == [stream]
+    assert {tensor_id for tensor_id, got_stream in calls if got_stream is stream} == expected_children

--- a/tests/test_curve_apply.py
+++ b/tests/test_curve_apply.py
@@ -6,6 +6,8 @@ from torch import nn
 from torch.nn import functional as F
 
 import comfy.model_patcher
+from comfy.weight_adapter.bypass import BypassForwardHook
+from comfy.weight_adapter.lora import LoRAAdapter
 
 from vdn_h3.apply import apply_adapters
 
@@ -66,7 +68,7 @@ def _converted(dense, rank, out, scale=1.0):
     }
 
 
-def test_curve_bypass_uses_native_projected_patches_not_weight_wrappers(tmp_path):
+def test_curve_bypass_uses_projected_post_hook_not_native_patches(tmp_path):
     torch.manual_seed(421)
     table = torch.randn(9, 3)
     dense, rank, out = 7, 2, 6
@@ -83,21 +85,24 @@ def test_curve_bypass_uses_native_projected_patches_not_weight_wrappers(tmp_path
 
     weight_key = "diffusion_model.blocks.0.adaln_proj.linear.weight"
     bias_key = "diffusion_model.blocks.0.adaln_proj.linear.bias"
-    assert weight_key in patcher.patches
-    assert bias_key in patcher.patches
+    assert weight_key not in patcher.patches
+    assert bias_key not in patcher.patches
     assert patcher.weight_wrapper_patches == {}
-    # Curve-only bypass has nothing to activation-hook; its exact projected
-    # native terms are ordinary Comfy weight/bias patches.
-    assert patcher.injections == {}
-    assert report["runtime_lowvram"]["weight_wrappers"] == 0
-    assert report["runtime_lowvram"]["bias_wrappers"] == 0
-    assert report["runtime_lowvram"]["forward_hooks"] == 0
-    assert (
-        report["curve_adaln_projection"]["mode"]
-        == "bypass_native_projected_patch"
-    )
-    assert report["curve_adaln_projection"]["weight_patches"] == 1
-    assert report["curve_adaln_projection"]["bias_patches"] == 1
+    assert "vdn_lora" in patcher.injections
+    runtime = report["runtime_lowvram"]
+    assert runtime["weight_wrappers"] == 0
+    assert runtime["bias_wrappers"] == 0
+    assert runtime["forward_hooks"] == 1
+    assert runtime["projected_curve_runtime_targets"] == 1
+    assert runtime["projected_curve_weight_patches"] == 0
+    assert runtime["projected_curve_bias_patches"] == 0
+    assert runtime["runtime_preloaded_on_inject"] is True
+    assert runtime["managed_adapter_bytes"] > 0
+    projection = report["curve_adaln_projection"]
+    assert projection["mode"] == "bypass_post_forward_projected_residual"
+    assert projection["weight_patches"] == 0
+    assert projection["bias_patches"] == 0
+    assert projection["runtime_targets"] == 1
 
 
 def test_curve_merge_registers_normal_weight_and_bias_patches(tmp_path):
@@ -124,9 +129,10 @@ def test_curve_merge_registers_normal_weight_and_bias_patches(tmp_path):
     assert report["curve_adaln_projection"]["mode"] == "merge"
     assert report["curve_adaln_projection"]["weight_patches"] == 1
     assert report["curve_adaln_projection"]["bias_patches"] == 1
+    assert report["curve_adaln_projection"]["runtime_targets"] == 0
 
 
-def test_curve_bypass_projected_patch_matches_affine_dense_delta(tmp_path):
+def test_curve_bypass_projected_post_hook_matches_affine_dense_delta(tmp_path):
     torch.manual_seed(424)
     table = torch.randn(9, 3)
     dense, rank, out = 7, 2, 6
@@ -139,6 +145,7 @@ def test_curve_bypass_projected_patch_matches_affine_dense_delta(tmp_path):
     )
     base_weight = linear.weight.detach().clone()
     base_bias = linear.bias.detach().clone()
+    true_forward = linear.forward
     a = torch.randn(rank, dense)
     b = torch.randn(out, rank)
     strength = 0.625
@@ -159,10 +166,73 @@ def test_curve_bypass_projected_patch_matches_affine_dense_delta(tmp_path):
 
     patcher.patch_model(device_to=torch.device("cpu"))
     try:
-        got = F.linear(coords, linear.weight, linear.bias)
+        assert linear.forward == true_forward
+        assert torch.equal(linear.weight, base_weight)
+        assert torch.equal(linear.bias, base_bias)
+        got = linear(coords)
         assert torch.allclose(got, expected, atol=2e-5, rtol=2e-5)
     finally:
         patcher.unpatch_model(device_to=torch.device("cpu"))
 
+    assert linear.forward == true_forward
     assert torch.equal(linear.weight, base_weight)
     assert torch.equal(linear.bias, base_bias)
+
+
+def test_curve_bypass_coexists_with_external_comfy_bypass_chain(tmp_path, monkeypatch):
+    torch.manual_seed(425)
+    table = torch.randn(9, 3)
+    dense, rank, out = 7, 2, 6
+    basis = torch.randn(3, dense)
+    mean = torch.randn(dense)
+    stage = _stage(tmp_path, basis, mean)
+    patcher = _patcher(table, out)
+    linear = patcher.get_model_object(
+        "diffusion_model.blocks.0.adaln_proj.linear"
+    )
+    true_forward = linear.forward
+
+    vdn_a = torch.randn(rank, dense)
+    vdn_b = torch.randn(out, rank)
+    apply_adapters(
+        patcher,
+        {"turbo": {"blocks.0.adaln_proj.linear": (vdn_a, vdn_b, 1.0)}},
+        0.7,
+        mode="bypass",
+        stage_path=str(stage),
+    )
+
+    ext_down = torch.randn(2, 3)
+    ext_up = torch.randn(out, 2)
+    alpha = torch.tensor(float(ext_down.shape[0]))
+    adapter = LoRAAdapter(
+        set(), (ext_up, ext_down, alpha, None, None, None)
+    )
+    external = BypassForwardHook(linear, adapter, multiplier=0.4)
+    monkeypatch.setattr(
+        "comfy.model_management.get_torch_device", lambda: torch.device("cpu")
+    )
+
+    injection = patcher.injections["vdn_lora"][0]
+    coords = torch.randn(4, 3)
+    dense_input = mean + coords @ basis
+    vdn_delta = F.linear(F.linear(dense_input, vdn_a), vdn_b) * 0.7
+    ext_delta = F.linear(F.linear(coords, ext_down), ext_up) * 0.4
+    base = true_forward(coords)
+
+    external.inject()
+    external_forward = linear.forward
+    injection.inject(patcher)
+    try:
+        assert linear.forward == external_forward
+        assert torch.allclose(
+            linear(coords), base + ext_delta + vdn_delta, atol=2e-5, rtol=2e-5
+        )
+        injection.eject(patcher)
+        assert linear.forward == external_forward
+        assert torch.allclose(linear(coords), base + ext_delta, atol=2e-5, rtol=2e-5)
+    finally:
+        injection.eject(patcher)
+        external.eject()
+
+    assert linear.forward == true_forward

--- a/tests/test_quantized_patch.py
+++ b/tests/test_quantized_patch.py
@@ -10,11 +10,11 @@ from vdn_h3.apply import apply_adapters
 
 
 class QuantizedLikeLinear(nn.Module):
-    """Synthetic custom-weight module for merge and activation-bypass lifecycles.
+    """Synthetic custom-weight module for merge and non-mutating runtime-bypass lifecycles.
 
     ``convert_weight`` / ``set_weight`` stand in for dequantize/requantize in the
     eager merge path. ``weight_function`` remains present specifically so the
-    bypass regression can assert that v1.5.1 no longer installs a weight wrapper
+    bypass regression can assert that the runtime path installs neither a weight wrapper nor a forward replacement
     or forces this custom-weight module onto that path.
     """
 
@@ -147,7 +147,7 @@ def test_bypass_custom_weight_preserves_native_weight_path():
         assert module.set_calls == 0
         assert torch.equal(module.weight, base_weight)
         assert len(module.weight_function) == 0
-        assert module.forward != true_forward
+        assert module.forward == true_forward
 
         x = torch.randn(4, 8)
         expected = F.linear(x, base_weight) + F.linear(F.linear(x, a), b)
@@ -182,7 +182,7 @@ def test_bypass_repeated_custom_weight_clone_cycles_do_not_accumulate():
         clone.patch_model(device_to=torch.device("cpu"))
         try:
             assert len(module.weight_function) == 0, cycle
-            assert module.forward != true_forward, cycle
+            assert module.forward == true_forward, cycle
             assert torch.allclose(module(x), expected, atol=2e-6, rtol=2e-6), cycle
             assert torch.equal(module.weight, base_weight), cycle
         finally:

--- a/tests/test_runtime_introspection.py
+++ b/tests/test_runtime_introspection.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+import comfy.model_patcher
+
+from vdn_h3.apply import apply_adapters
+from vdn_h3.runtime_introspection import _build_runtime_adapter_registry
+
+
+class Diffusion(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8, bias=False)
+        self.use_adaln_curves = False
+
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.diffusion_model = Diffusion()
+        self.device = torch.device("cpu")
+
+
+def _patcher():
+    torch.manual_seed(511)
+    return comfy.model_patcher.ModelPatcher(
+        ToyModel(), torch.device("cpu"), torch.device("cpu")
+    )
+
+
+def _captured_registries(injection):
+    found = []
+    seen = set()
+    for function in (injection.inject, injection.eject):
+        for cell in getattr(function, "__closure__", None) or ():
+            try:
+                value = cell.cell_contents
+            except ValueError:
+                continue
+            adapters = getattr(value, "adapters", None)
+            if isinstance(adapters, dict) and id(value) not in seen:
+                seen.add(id(value))
+                found.append(value)
+    return found
+
+
+def test_bypass_injection_publishes_zero_copy_classic_lora_metadata():
+    patcher = _patcher()
+    a0 = torch.randn(3, 8)
+    b0 = torch.randn(8, 3)
+    a1 = torch.randn(2, 8)
+    b1 = torch.randn(8, 2)
+
+    apply_adapters(
+        patcher,
+        {
+            "default": {"linear": (a0, b0, 0.5)},
+            "turbo": {"linear": (a1, b1, 0.25)},
+        },
+        {"default": 0.8, "turbo": 0.6},
+        mode="bypass",
+        stage_path=None,
+    )
+
+    injection = patcher.injections["vdn_lora"][0]
+    registries = _captured_registries(injection)
+    assert len(registries) == 1
+    entries = registries[0].adapters
+    assert len(entries) == 2
+    assert "diffusion_model.linear.weight" in entries
+    assert any(key.startswith("diffusion_model.linear.weight#vdn-runtime-") for key in entries)
+
+    factors = []
+    for adapter, strength in entries.values():
+        assert adapter.name == "lora"
+        up, down, alpha, mid, dora_scale, reshape = adapter.weights
+        assert alpha == float(down.shape[0])
+        assert mid is dora_scale is reshape is None
+        factors.append((down, up, strength))
+
+    # Metadata must describe exactly the same sum of low-rank operators without
+    # allocating concatenated copies of the factors.
+    x = torch.randn(4, 8)
+    got = sum(
+        torch.nn.functional.linear(torch.nn.functional.linear(x, down), up) * strength
+        for down, up, strength in factors
+    )
+    expected = (
+        torch.nn.functional.linear(torch.nn.functional.linear(x, a0), b0) * 0.4
+        + torch.nn.functional.linear(torch.nn.functional.linear(x, a1), b1) * 0.15
+    )
+    assert torch.allclose(got, expected, atol=1e-6, rtol=1e-6)
+
+    referenced = {
+        id(value)
+        for adapter, _strength in entries.values()
+        for value in (adapter.weights[0], adapter.weights[1])
+    }
+    assert referenced == {id(a0), id(b0), id(a1), id(b1)}
+
+
+def test_projected_curve_metadata_marks_constant_bias_conservatively_unknown():
+    down = torch.randn(4, 8)
+    up = torch.randn(16, 4)
+    offset = torch.randn(16)
+    module = "blocks.49.adaln_proj.linear"
+
+    registry = _build_runtime_adapter_registry(
+        {module: [(down, up, 0.75)]},
+        {module: [(offset, 0.75)]},
+    )
+    assert set(registry.adapters) == {
+        "diffusion_model.blocks.49.adaln_proj.linear.weight",
+        "diffusion_model.blocks.49.adaln_proj.linear.bias",
+    }
+
+    weight_adapter, weight_strength = registry.adapters[
+        "diffusion_model.blocks.49.adaln_proj.linear.weight"
+    ]
+    bias_adapter, bias_strength = registry.adapters[
+        "diffusion_model.blocks.49.adaln_proj.linear.bias"
+    ]
+    assert weight_adapter.name == "lora"
+    assert weight_strength == 0.75
+    assert weight_adapter.weights[0] is up
+    assert weight_adapter.weights[1] is down
+    assert bias_adapter.name == "vdn_runtime_bias"
+    assert bias_strength == 0.75
+    assert bias_adapter.weights[0] is offset
+
+
+def test_introspection_wrapper_does_not_change_runtime_injection_math():
+    patcher = _patcher()
+    module = patcher.model.diffusion_model.linear
+    base_forward = module.forward
+    a = torch.randn(3, 8)
+    b = torch.randn(8, 3)
+    x = torch.randn(5, 8)
+    expected = base_forward(x) + torch.nn.functional.linear(
+        torch.nn.functional.linear(x, a), b
+    ) * 0.7
+
+    apply_adapters(
+        patcher,
+        {"default": {"linear": (a, b, 1.0)}},
+        0.7,
+        mode="bypass",
+        stage_path=None,
+    )
+    injection = patcher.injections["vdn_lora"][0]
+    injection.inject(patcher)
+    try:
+        assert module.forward == base_forward
+        assert torch.allclose(module(x), expected, atol=1e-6, rtol=1e-6)
+    finally:
+        injection.eject(patcher)
+    assert module.forward == base_forward

--- a/tests/test_runtime_lowvram.py
+++ b/tests/test_runtime_lowvram.py
@@ -56,13 +56,18 @@ def test_bypass_apply_uses_injection_and_never_weight_wrappers(monkeypatch):
     assert report["default"]["runtime_bypass_targets"] == 1
     assert report["default"]["runtime_weight_targets"] == 1
     runtime = report["runtime_lowvram"]
-    assert runtime["mode"] == "stack_safe_bypass"
+    assert runtime["mode"] == "post_forward_hook_bypass"
     assert runtime["forward_hooks"] == 1
+    assert runtime["pytorch_forward_post_hooks"] == 1
+    assert runtime["mutable_forward_wrappers"] == 0
+    assert runtime["module_forward_untouched"] is True
     assert runtime["weight_wrappers"] == 0
     assert runtime["bias_wrappers"] == 0
-    assert runtime["managed_adapter_bytes"] == 0
+    assert runtime["runtime_preloaded_on_inject"] is True
+    assert runtime["managed_adapter_bytes"] == a.numel() * a.element_size() + b.numel() * b.element_size()
     assert runtime["owner_key"] is None
     assert runtime["stack_safe_cross_provider"] is True
+    assert runtime["cross_provider_forward_chain_independent"] is True
 
     x = torch.randn(4, 8)
     base_out = true_forward(x)
@@ -73,6 +78,7 @@ def test_bypass_apply_uses_injection_and_never_weight_wrappers(monkeypatch):
     injection = vdn.injections["vdn_lora"][0]
     injection.inject(vdn)
     try:
+        assert module.forward == true_forward
         got = module(x)
         assert torch.allclose(got, want, atol=1e-5, rtol=1e-5)
     finally:
@@ -103,7 +109,7 @@ def test_bypass_no_longer_requires_weight_function_capability(monkeypatch):
     )
     # Plain nn.Linear deliberately has no Comfy weight_function list. v1.5.0
     # rejected this class because its bypass path depended on add_weight_wrapper;
-    # v1.5.1 must use the activation-side Comfy bypass contract instead.
+    # the VDN runtime path uses a PyTorch post-forward hook instead.
     base = _base_patcher()
     converted, _, _ = _converted()
     vdn = base.clone()

--- a/vdn_h3/__init__.py
+++ b/vdn_h3/__init__.py
@@ -1,0 +1,8 @@
+"""VDN-H3 runtime package initialization."""
+
+from .runtime_introspection import (
+    install_runtime_introspection_bridge as _install_runtime_introspection_bridge,
+)
+
+_install_runtime_introspection_bridge()
+del _install_runtime_introspection_bridge

--- a/vdn_h3/apply.py
+++ b/vdn_h3/apply.py
@@ -2,39 +2,53 @@
 
 ``merge`` uses normal ``ModelPatcher.add_patches`` weight ownership.
 
-``bypass`` keeps the workflow-facing low-residency mode but deliberately uses
-ComfyUI's activation-side ``BypassForwardHook`` contract for ordinary LoRA
-targets. The hooks are installed through a stack-safe VDN injection that keeps
-VDN inside any independently managed Comfy bypass chain and can splice VDN back
-out without restoring stale ``module.forward`` objects.
+``bypass`` is the low-residency execution mode. Ordinary VDN LoRA terms are
+implemented with PyTorch forward *post-hooks*, not Comfy ``BypassForwardHook``
+and not ``ModelPatcher.weight_function``. VDN therefore never replaces or
+splices ``module.forward`` and cannot participate in another provider's mutable
+forward-wrapper linked list.
 
-This is intentional for quantized MiniMax-H3 bases: using a ModelPatcher
-``weight_function`` on those layers forces Comfy's dequantized weight path. In
-the real stacked VDN + external runtime-DoRA workflow that v1.5.0 path regressed
-into a CUDA illegal-memory-access abort. The stack-safe hook path preserves the
-native quantized base forward and is the path previously validated with the same
-cross-provider Continuum lifecycle.
+For pruned/curve MiniMax-H3, bypass mode also keeps the projected AdaLN updates
+out of the base parameter tree. The exact affine projection (basis + mean) is
+computed once on CPU, then the resulting low-rank curve-coordinate residual and
+constant bias are added by the same post-forward mechanism. This is deliberate:
+materializing the projected curve terms as native weight/bias patches changes the
+execution/storage path of the pruned base before the first attention projection.
+The production RTX PRO 6000 trace that invalidated the first v1.5.2 candidate
+reported the CUDA fault at the first ordinary VDN post-hook, but that hook runs
+after the module forward; the preceding VDN-specific operation in the block was
+the materialized curve-AdaLN update. Bypass now leaves those base parameters
+untouched as well.
 
-Full-width AdaLN LoRAs on a curve/pruned H3 base are projected once through the
-exact pruning affine (basis + mean). Their projected native curve weight and
-constant bias terms stay under ordinary Comfy weight-patch ownership even in
-``bypass`` mode; no dense timestep MLP reconstruction is used.
+All runtime adapter factors are staged onto the compute device when the
+``PatcherInjection`` is injected. The first H3 forward therefore performs no VDN
+adapter H2D transfer and cannot use a transfer merely as the asynchronous CUDA
+error-reporting boundary. Unexpected device/dtype changes still have a synchronous
+fallback conversion for correctness.
+
+Fused INT8 ``mlp.fc2`` targets whose H3 fast path bypasses ``module.forward``
+remain ordinary Comfy weight patches. In ``merge`` mode, projected curve-AdaLN
+weight/bias terms also remain ordinary Comfy patches.
 """
 from __future__ import annotations
 
 import logging
+import threading
+import weakref
+from collections import defaultdict
 
 import torch
 import torch.nn.functional as F
 
 import comfy.lora
+import comfy.model_management
 import comfy.patcher_extension
 import comfy.utils
-import comfy.weight_adapter
 
 from vdn_h3.curve_affine import find_curve_affine, project_curve_terms
 
 _log = logging.getLogger("comfy.vdn")
+_FLOAT_DTYPES = (torch.float16, torch.bfloat16, torch.float32, torch.float64)
 
 
 def _is_adaln(module: str) -> bool:
@@ -108,7 +122,7 @@ def _native_patch_adapter(new_model, converted, strength: float) -> int:
 
 
 def _native_patch_projected_curve(new_model, terms_by_module, bias_terms_by_module):
-    """Apply projected curve LoRAs + their constant terms through normal patches."""
+    """Apply projected curve LoRAs + constants through normal patches (merge only)."""
     weight_patches = 0
     bias_patches = 0
     state_keys = set(new_model.model.state_dict().keys())
@@ -141,31 +155,12 @@ def _native_patch_projected_curve(new_model, terms_by_module, bias_terms_by_modu
     return weight_patches, bias_patches
 
 
-class _FrugalLoRA(comfy.weight_adapter.LoRAAdapter):
-    """Activation-side LoRA used by VDN's stack-safe bypass path."""
-
-    def bypass_forward(self, org_forward, x, *args, **kwargs):
-        base_out = org_forward(x, *args, **kwargs)
-        if getattr(self, "is_conv", False):
-            return super().bypass_forward(org_forward, x, *args, **kwargs)
-
-        up, down, alpha = self.weights[0], self.weights[1], self.weights[2]
-        rank = down.shape[0]
-        scale = (
-            (alpha / rank if alpha is not None else 1.0)
-            * getattr(self, "multiplier", 1.0)
-        )
-        down = down.to(dtype=x.dtype)
-        up = up.to(dtype=x.dtype)
-        return base_out.add_(F.linear(F.linear(x, down), up), alpha=scale)
-
-
 def _int8_fused_fc2(dm, modules):
     """Return fc2 targets whose fused quantized forward bypasses module.forward.
 
-    These targets cannot use an activation-side hook because H3's fused path reads
-    the underlying linear weight directly. Keep them under normal Comfy weight
-    patching, matching the previously validated PR #1 behavior.
+    A PyTorch forward hook cannot observe these H3 fused calls. Keep these terms
+    under normal Comfy weight-patch ownership, matching the previously validated
+    quantized path.
     """
     fused = []
     for module in modules:
@@ -183,167 +178,239 @@ def _int8_fused_fc2(dm, modules):
     return fused
 
 
-def _bypass(new_model, converted, modules, strength, hooks):
-    if not modules:
-        return 0
-    subset = {module: converted[module] for module in modules}
-    loaded, key_map = _load_comfy_adapter(new_model, subset)
+def _tensor_bytes(tensor: torch.Tensor) -> int:
+    return int(tensor.numel()) * int(tensor.element_size())
 
-    manager = comfy.weight_adapter.BypassInjectionManager()
-    installed = 0
-    for module in modules:
-        key = key_map[module]
-        adapter = loaded.get(key)
-        if adapter is None:
-            continue
-        if isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
-            adapter = _FrugalLoRA(adapter.loaded_keys, adapter.weights)
-        elif not isinstance(adapter, comfy.weight_adapter.WeightAdapterBase):
-            raise RuntimeError(
-                f"VDN bypass target {key} produced unsupported adapter "
-                f"{type(adapter).__name__}"
-            )
-        manager.add_adapter(key, adapter, strength=float(strength))
-        installed += 1
 
-    manager.create_injections(new_model.model)
-    hooks.extend(manager.hooks)
-    if len(manager.hooks) != installed:
-        raise RuntimeError(
-            f"VDN bypass created {len(manager.hooks)} hooks for {installed} adapters"
+def _runtime_source_bytes(terms_by_module, bias_terms_by_module) -> int:
+    total = 0
+    for terms in terms_by_module.values():
+        for down, up, _scale in terms:
+            total += _tensor_bytes(down) + _tensor_bytes(up)
+    for terms in bias_terms_by_module.values():
+        for offset, _scale in terms:
+            total += _tensor_bytes(offset)
+    return total
+
+
+def _module_compute_device_dtype(module, fallback_dtype: torch.dtype):
+    device = torch.device(comfy.model_management.get_torch_device())
+    dtype = getattr(getattr(module, "weight", None), "dtype", None)
+    if dtype not in _FLOAT_DTYPES:
+        dtype = fallback_dtype if fallback_dtype in _FLOAT_DTYPES else torch.bfloat16
+    return device, dtype
+
+
+class _PostForwardLoRA:
+    """Exact additive low-rank residual without replacing ``module.forward``.
+
+    ``terms`` are ``(down, up, scale)`` factors. ``bias_terms`` are optional
+    ``(offset, scale)`` constants used by the exact pruned-AdaLN affine projection.
+    Source tensors remain CPU/checkpoint-owned. Device copies are created at
+    injection time for the module's normal compute device/dtype and dropped on
+    eject/replacement. A synchronous fallback handles an unexpected activation
+    device/dtype without relying on an asynchronous H2D copy inside the first H3
+    forward.
+    """
+
+    def __init__(self, terms, bias_terms=()):
+        self.terms = tuple(
+            (down.detach(), up.detach(), float(scale))
+            for down, up, scale in terms
         )
-    return installed
+        self.bias_terms = tuple(
+            (offset.detach(), float(scale))
+            for offset, scale in bias_terms
+        )
+        if not self.terms and not self.bias_terms:
+            raise RuntimeError("VDN post-forward hook has no adapter terms")
+        self._cache = {}
 
+    def _fallback_dtype(self):
+        for down, up, _scale in self.terms:
+            if down.dtype in _FLOAT_DTYPES:
+                return down.dtype
+            if up.dtype in _FLOAT_DTYPES:
+                return up.dtype
+        for offset, _scale in self.bias_terms:
+            if offset.dtype in _FLOAT_DTYPES:
+                return offset.dtype
+        return torch.bfloat16
 
-def _same_bound_method(left, right):
-    """Identity check stable across repeated bound-method attribute reads."""
-    if left is right:
-        return True
-    left_self = getattr(left, "__self__", None)
-    right_self = getattr(right, "__self__", None)
-    left_func = getattr(left, "__func__", None)
-    right_func = getattr(right, "__func__", None)
-    return (
-        left_self is right_self
-        and left_func is not None
-        and left_func is right_func
-    )
+    def _compile(self, device, dtype):
+        device = torch.device(device)
+        key = (device.type, device.index, dtype)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
 
+        downs = []
+        ups = []
+        for down, up, scale in self.terms:
+            # Blocking copies are intentional. Injection is the ownership boundary;
+            # the model forward should not become an H2D synchronization/error probe.
+            down_active = down.to(device=device, dtype=dtype, non_blocking=False)
+            up_active = up.to(device=device, dtype=dtype, non_blocking=False)
+            if scale != 1.0:
+                up_active = up_active * scale
+            downs.append(down_active)
+            ups.append(up_active)
 
-def _bypass_hook_owner(forward):
-    """Return the Comfy bypass hook owning a bound forward, if there is one."""
-    hook_type = getattr(comfy.weight_adapter, "BypassForwardHook", None)
-    owner = getattr(forward, "__self__", None)
-    if isinstance(hook_type, type) and isinstance(owner, hook_type):
-        return owner
-    return None
+        down_cat = None
+        up_cat = None
+        if downs:
+            down_cat = downs[0] if len(downs) == 1 else torch.cat(downs, dim=0)
+            up_cat = ups[0] if len(ups) == 1 else torch.cat(ups, dim=1)
 
+        bias = None
+        for offset, scale in self.bias_terms:
+            active = offset.to(device=device, dtype=dtype, non_blocking=False)
+            if scale != 1.0:
+                active = active * scale
+            bias = active if bias is None else bias + active
 
-def _inject_hook_stack_safe(hook):
-    """Inject VDN below any already-active Comfy bypass-hook chain."""
-    if getattr(hook, "original_forward", None) is not None:
-        return
+        cached = (down_cat, up_cat, bias)
+        self._cache[key] = cached
+        return cached
 
-    module = hook.module
-    previous_forward = module.forward
-    hook.inject()  # lets Comfy set adapter metadata/device placement
+    def prepare(self, module):
+        device, dtype = _module_compute_device_dtype(module, self._fallback_dtype())
+        self._compile(device, dtype)
 
-    outer = _bypass_hook_owner(previous_forward)
-    if outer is None:
-        return
+    def _weights_for(self, x: torch.Tensor):
+        key = (x.device.type, x.device.index, x.dtype)
+        cached = self._cache.get(key)
+        if cached is None:
+            # Unexpected mixed-dtype/device execution remains supported, but keep the
+            # conversion synchronous so allocator errors are reported at this exact
+            # ownership boundary rather than being deferred into later kernels.
+            cached = self._compile(x.device, x.dtype)
+        return cached
 
-    current = outer
-    seen = set()
-    while True:
-        marker = id(current)
-        if marker in seen:
-            module.forward = previous_forward
-            hook.original_forward = None
-            raise RuntimeError("VDN found a cyclic Comfy bypass-forward chain")
-        seen.add(marker)
-
-        inner_forward = getattr(current, "original_forward", None)
-        inner = _bypass_hook_owner(inner_forward)
-        if inner is None:
-            break
-        current = inner
-
-    # hook.inject() temporarily made VDN outermost. Restore the existing chain,
-    # then splice VDN immediately above its true/base forward instead.
-    module.forward = previous_forward
-    hook.original_forward = inner_forward
-    current.original_forward = hook._bypass_forward
-
-
-def _eject_hook_stack_safe(hook):
-    """Remove a VDN hook even when another Comfy bypass hook still wraps it."""
-    original_forward = getattr(hook, "original_forward", None)
-    if original_forward is None:
-        return
-
-    module = hook.module
-    target = hook._bypass_forward
-    current_forward = module.forward
-
-    if _same_bound_method(current_forward, target):
-        module.forward = original_forward
-        hook.original_forward = None
-        return
-
-    current = _bypass_hook_owner(current_forward)
-    seen = set()
-    while current is not None:
-        marker = id(current)
-        if marker in seen:
+    def __call__(self, module, inputs, output):
+        if not isinstance(output, torch.Tensor):
             raise RuntimeError(
-                "VDN found a cyclic Comfy bypass-forward chain during eject"
+                f"VDN post-forward bypass expected Tensor output from "
+                f"{type(module).__name__}, got {type(output).__name__}"
             )
-        seen.add(marker)
+        if not inputs or not isinstance(inputs[0], torch.Tensor):
+            raise RuntimeError(
+                f"VDN post-forward bypass expected the first positional input to "
+                f"{type(module).__name__} to be a Tensor"
+            )
+        x = inputs[0]
+        down, up, bias = self._weights_for(x)
+        delta = None
+        if down is not None:
+            delta = F.linear(F.linear(x, down), up)
+        if bias is not None:
+            delta = bias if delta is None else delta + bias
+        if delta is None:
+            return output
+        return output + delta
 
-        inner_forward = getattr(current, "original_forward", None)
-        if _same_bound_method(inner_forward, target):
-            current.original_forward = original_forward
-            hook.original_forward = None
-            return
-        current = _bypass_hook_owner(inner_forward)
-
-    # Another provider may already have detached this hook. Never resurrect a
-    # stale original over the currently valid live chain.
-    hook.original_forward = None
+    def clear(self):
+        self._cache.clear()
 
 
-def _install_injection(new_model, hooks):
-    """Install one clone- and cross-provider-safe VDN bypass injection."""
-    if not hooks:
-        return
+# ModelPatcher clones share the same inner model. Track the currently active VDN
+# registration outside the model object so a newer clone can replace an older
+# registration without private attributes on the model and so an old clone's
+# later eject cannot tear down the newer generation.
+_ACTIVE_POST_FORWARD = weakref.WeakKeyDictionary()
+_ACTIVE_POST_FORWARD_LOCK = threading.RLock()
 
-    owner = new_model.model  # clone-shared inner model
+
+def _remove_post_forward_registration(registration):
+    for handle in reversed(registration["handles"]):
+        handle.remove()
+    for plan in registration["plans"]:
+        plan.clear()
+
+
+def _install_post_forward_injection(
+    new_model,
+    dm,
+    terms_by_module,
+    bias_terms_by_module=None,
+):
+    bias_terms_by_module = bias_terms_by_module or {}
+    paths = sorted(set(terms_by_module) | set(bias_terms_by_module))
+    if not paths:
+        return 0
+
+    plans = []
+    for path in paths:
+        module = comfy.utils.get_attr(dm, path)
+        register = getattr(module, "register_forward_hook", None)
+        if not callable(register):
+            raise RuntimeError(
+                f"VDN bypass target {path!r} ({type(module).__name__}) does not "
+                "support PyTorch forward hooks"
+            )
+        plans.append((
+            path,
+            module,
+            _PostForwardLoRA(
+                terms_by_module.get(path, ()),
+                bias_terms_by_module.get(path, ()),
+            ),
+        ))
+
+    owner = new_model.model
+    token = object()
 
     def inject_all(model_patcher):
-        old = getattr(owner, "_vdn_live_hooks", None)
-        if old:
-            for hook in reversed(old):
-                _eject_hook_stack_safe(hook)
-        try:
-            for hook in hooks:
-                _inject_hook_stack_safe(hook)
-        except Exception:
-            for hook in reversed(hooks):
-                _eject_hook_stack_safe(hook)
-            raise
-        owner._vdn_live_hooks = hooks
+        del model_patcher
+        with _ACTIVE_POST_FORWARD_LOCK:
+            current = _ACTIVE_POST_FORWARD.get(owner)
+            if current is not None and current["token"] is token:
+                return
+            if current is not None:
+                _remove_post_forward_registration(current)
+
+            handles = []
+            hook_plans = [plan for _, _, plan in plans]
+            try:
+                # Stage every adapter tensor before registering any hook. If a copy
+                # fails, no partial runtime adapter topology becomes visible.
+                for _, module, plan in plans:
+                    plan.prepare(module)
+                for _, module, plan in plans:
+                    handles.append(module.register_forward_hook(plan))
+            except Exception:
+                for handle in reversed(handles):
+                    handle.remove()
+                for plan in hook_plans:
+                    plan.clear()
+                raise
+
+            _ACTIVE_POST_FORWARD[owner] = {
+                "token": token,
+                "handles": handles,
+                "plans": hook_plans,
+            }
 
     def eject_all(model_patcher):
-        for hook in reversed(hooks):
-            _eject_hook_stack_safe(hook)
-        if getattr(owner, "_vdn_live_hooks", None) is hooks:
-            owner._vdn_live_hooks = None
+        del model_patcher
+        with _ACTIVE_POST_FORWARD_LOCK:
+            current = _ACTIVE_POST_FORWARD.get(owner)
+            # A newer clone may already have replaced this registration. An old
+            # eject must not remove the newer generation.
+            if current is None or current["token"] is not token:
+                return
+            _remove_post_forward_registration(current)
+            try:
+                del _ACTIVE_POST_FORWARD[owner]
+            except KeyError:
+                pass
 
     injection = comfy.patcher_extension.PatcherInjection(
         inject=inject_all,
         eject=eject_all,
     )
     new_model.set_injections("vdn_lora", [injection])
+    return len(plans)
 
 
 def apply_adapters(
@@ -354,7 +421,7 @@ def apply_adapters(
     stage_path=None,
     verbose=False,
 ):
-    """Apply released VDN adapters through merge or stack-safe bypass mode."""
+    """Apply released VDN adapters through merge or non-mutating runtime bypass."""
     if mode not in ("merge", "bypass"):
         raise ValueError(
             f"VDN lora_mode must be 'merge' or 'bypass', got {mode!r}"
@@ -365,7 +432,8 @@ def apply_adapters(
     pruned = _is_pruned_base(dm)
     report = {}
     curve_terms = {}
-    all_hooks = []
+    runtime_terms = defaultdict(list)
+    runtime_bias_terms = defaultdict(list)
 
     for name, converted in converted_by_name.items():
         s = float(per_name.get(name, 1.0) if per_name is not None else strength)
@@ -393,13 +461,12 @@ def apply_adapters(
             bypass_modules = [module for module in modules if module not in fused]
             fused_terms = {module: ordinary[module] for module in sorted(fused)}
 
-            bypass_targets = _bypass(
-                new_model,
-                ordinary,
-                bypass_modules,
-                s,
-                all_hooks,
-            )
+            for module in bypass_modules:
+                down, up, term_scale = ordinary[module]
+                runtime_terms[module].append(
+                    (down, up, float(term_scale) * s)
+                )
+            bypass_targets = len(bypass_modules)
             if fused_terms:
                 fused_native_targets = _native_patch_adapter(
                     new_model, fused_terms, s
@@ -409,8 +476,8 @@ def apply_adapters(
         report[name] = {
             "native_weight_patches": native_patches,
             "runtime_bypass_targets": bypass_targets,
-            # Kept for one release as a compatibility/logging alias. It no longer
-            # means ModelPatcher weight wrappers in v1.5.1.
+            # Kept as a compatibility/logging alias. In v1.5.2 it counts
+            # non-mutating runtime adapter terms, not ModelPatcher weight wrappers.
             "runtime_weight_targets": bypass_targets,
             "fused_native_targets": fused_native_targets,
             "curve_adaln": curve_count,
@@ -418,7 +485,7 @@ def apply_adapters(
         }
         if verbose:
             _log.info(
-                "[vdn] adapter %s: %d native patches, %d stack-safe bypass targets, "
+                "[vdn] adapter %s: %d native patches, %d post-forward bypass targets, "
                 "%d fused-native targets, %d curve AdaLN",
                 name,
                 native_patches,
@@ -460,26 +527,54 @@ def apply_adapters(
 
     curve_weight_patches = 0
     curve_bias_patches = 0
+    curve_runtime_targets = 0
     if projected_curve or curve_bias_terms:
-        curve_weight_patches, curve_bias_patches = _native_patch_projected_curve(
-            new_model,
-            projected_curve,
-            curve_bias_terms,
-        )
+        if mode == "merge":
+            curve_weight_patches, curve_bias_patches = _native_patch_projected_curve(
+                new_model,
+                projected_curve,
+                curve_bias_terms,
+            )
+        else:
+            for module, terms in projected_curve.items():
+                runtime_terms[module].extend(terms)
+            for module, terms in curve_bias_terms.items():
+                runtime_bias_terms[module].extend(terms)
+            curve_runtime_targets = len(
+                set(projected_curve) | set(curve_bias_terms)
+            )
 
     if mode == "bypass":
-        _install_injection(new_model, all_hooks)
+        forward_hook_modules = _install_post_forward_injection(
+            new_model,
+            dm,
+            runtime_terms,
+            runtime_bias_terms,
+        )
+        runtime_term_count = sum(len(terms) for terms in runtime_terms.values())
+        runtime_bias_count = sum(len(terms) for terms in runtime_bias_terms.values())
         runtime_report = {
-            "mode": "stack_safe_bypass",
-            "forward_hooks": len(all_hooks),
+            "mode": "post_forward_hook_bypass",
+            "forward_hooks": forward_hook_modules,
+            "pytorch_forward_post_hooks": forward_hook_modules,
+            "runtime_terms": runtime_term_count,
+            "runtime_bias_terms": runtime_bias_count,
+            "runtime_preloaded_on_inject": True,
+            "mutable_forward_wrappers": 0,
+            "module_forward_untouched": True,
             "weight_wrappers": 0,
             "bias_wrappers": 0,
-            "managed_adapter_bytes": 0,
+            "managed_adapter_bytes": _runtime_source_bytes(
+                runtime_terms,
+                runtime_bias_terms,
+            ),
             "delta_buffer_limit_bytes": 0,
             "owner_key": None,
             "stack_safe_cross_provider": True,
-            "projected_curve_weight_patches": curve_weight_patches,
-            "projected_curve_bias_patches": curve_bias_patches,
+            "cross_provider_forward_chain_independent": True,
+            "projected_curve_runtime_targets": curve_runtime_targets,
+            "projected_curve_weight_patches": 0,
+            "projected_curve_bias_patches": 0,
         }
         report["runtime_bypass"] = runtime_report
         # Preserve the v1.5.0 report key for callers/log parsers while making the
@@ -490,10 +585,12 @@ def apply_adapters(
         report["curve_adaln_projection"] = {
             "source": affine.source,
             "mode": (
-                "merge" if mode == "merge" else "bypass_native_projected_patch"
+                "merge" if mode == "merge"
+                else "bypass_post_forward_projected_residual"
             ),
             "weight_patches": curve_weight_patches,
             "bias_patches": curve_bias_patches,
+            "runtime_targets": curve_runtime_targets,
             "dense_width": int(affine.mean.shape[0]),
             "curve_width": int(affine.basis.shape[0]),
         }

--- a/vdn_h3/nodes.py
+++ b/vdn_h3/nodes.py
@@ -265,9 +265,9 @@ class ApplyVDNH3:
             "lora_mode": (["merge", "bypass"], {
                 "default": "merge",
                 "tooltip": "merge uses normal Comfy weight patches. bypass uses "
-                           "stack-safe Comfy BypassForwardHook adapters for ordinary "
-                           "targets, preserving native quantized forwards while safely "
-                           "stacking with other runtime bypass providers."}),
+                           "VDN-owned PyTorch forward post-hooks, pre-stages runtime "
+                           "factors before H3 execution, and leaves pruned curve AdaLN "
+                           "base weights untouched; fused INT8 fc2 remains native."}),
             "branch_weights": (["auto", "stream", "resident"], {
                 "default": "auto",
                 "tooltip": "auto: resident BF16 when the base-reserved VRAM budget "
@@ -319,9 +319,9 @@ class ApplyVDNH3Advanced:
                 "default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
             "lora_mode": (["merge", "bypass"], {
                 "default": "merge",
-                "tooltip": "bypass uses VDN's stack-safe Comfy bypass-hook lifecycle "
-                           "for ordinary LoRA targets; projected curve AdaLN remains "
-                           "under normal native weight/bias patches."}),
+                "tooltip": "bypass uses VDN-owned PyTorch forward post-hooks and "
+                           "never replaces module.forward or materializes projected "
+                           "curve AdaLN base weights; fused INT8 fc2 stays native."}),
             "branch_weights": (["auto", "stream", "resident"], {"default": "auto"}),
             "retain_buffers": (["auto", "on", "off"], {"default": "auto"}),
             "verbose": ("BOOLEAN", {"default": False}),

--- a/vdn_h3/runtime.py
+++ b/vdn_h3/runtime.py
@@ -12,6 +12,15 @@ scratch is never raced across ModelPatcher clones or threads.
 Branch *weights* do not live here. They remain either bounded streamed checkpoint
 descriptors or a ComfyUI-managed additional ModelPatcher. The only process-global
 runtime object is one bounded worker executor; it owns no model tensors or cache.
+
+Cross-stream ownership is explicit even with ``cudaMallocAsync``. PyTorch's async
+allocator still uses ``record_stream`` to learn about streams other than an
+allocation's creation stream before ``cudaFreeAsync`` can safely recycle storage.
+VDN prefetch allocates on a dedicated producer stream and consumes on the caller's
+stream, so this is exactly the cross-stream case that must be recorded. The warning
+about redundant ``record_stream`` calls under ``cudaMallocAsync`` concerns recording
+the allocation/creation stream itself; it does not make side-stream lifetime
+tracking unnecessary.
 """
 from __future__ import annotations
 
@@ -36,7 +45,6 @@ _ACTIVE_BUFFERS = contextvars.ContextVar("vdn_active_runtime_buffers", default=N
 # each RuntimeBuffers owns at most one Future/result and drops it on reset.
 _PREFETCH_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
     max_workers=1, thread_name_prefix="vdn-branch-prefetch")
-_RECORD_STREAM_NEEDED = None
 
 
 def current_runtime_buffers():
@@ -53,24 +61,6 @@ def _bounded_put(mapping, key, value, limit):
     return value
 
 
-def _record_stream_needed():
-    """Whether torch's allocator requires explicit record_stream ownership.
-
-    Under cudaMallocAsync the allocator is stream ordered already. record_stream is a
-    no-op there and recent torch versions warn for every call. This mirrors upstream
-    VDN v1.4.3 while keeping the decision in this fork's state-owned prefetch layer.
-    """
-    global _RECORD_STREAM_NEEDED
-    if _RECORD_STREAM_NEEDED is None:
-        try:
-            _RECORD_STREAM_NEEDED = torch.cuda.get_allocator_backend() != "cudaMallocAsync"
-        except Exception:
-            # Older/custom torch builds may not expose the allocator query. Preserve
-            # the conservative caching-allocator behavior in that case.
-            _RECORD_STREAM_NEEDED = True
-    return _RECORD_STREAM_NEEDED
-
-
 class _StreamPrefetcher:
     """One cancellable in-flight block transfer; no per-state worker/thread leak."""
 
@@ -82,8 +72,15 @@ class _StreamPrefetcher:
 
     @staticmethod
     def _record_stream(tensor, stream):
-        if not _record_stream_needed():
-            return
+        """Record the consumer stream for every storage backing a streamed weight.
+
+        Prefetched weights are allocated on a dedicated CUDA stream and later read
+        by the model's current stream. Both PyTorch's native caching allocator and
+        its ``cudaMallocAsync`` allocator require the non-creation usage stream to
+        be recorded so storage cannot be recycled before the consumer finishes.
+        QuantizedTensor wrappers may own several underlying CUDA tensors; record all
+        of them best-effort.
+        """
         seen = [tensor]
         inner = getattr(tensor, "_qdata", None)
         if isinstance(inner, torch.Tensor):

--- a/vdn_h3/runtime_introspection.py
+++ b/vdn_h3/runtime_introspection.py
@@ -1,0 +1,183 @@
+"""Read-only metadata bridge for VDN's non-mutating runtime adapters.
+
+The v1.5.2 bypass path deliberately uses PyTorch forward post-hooks instead of
+Comfy ``BypassForwardHook`` objects or ``ModelPatcher`` weight wrappers.  That
+keeps the quantized H3 execution path isolated, but it also means consumers that
+inspect ``ModelPatcher.injections`` before sampling cannot infer which LoRA terms
+will become active when the injection is installed.
+
+Spectrum H3's model-aware profiler is one such consumer.  It already understands
+the ordinary Comfy ``BypassInjectionManager.adapters`` convention by inspecting a
+``PatcherInjection`` closure.  Publish the same *read-only* adapter metadata shape
+without changing VDN execution ownership: the real injection still installs only
+the post-forward hooks created in :mod:`vdn_h3.apply`.
+
+The metadata keeps references to the existing CPU adapter factors; it never
+concatenates or copies them.  Projected curve-AdaLN low-rank terms are exposed as
+ordinary LoRA metadata while their required constant offsets are exposed as an
+explicit non-LoRA entry.  A profiler that understands classic LoRA can therefore
+measure the low-rank part exactly and conservatively count the constant term as an
+unknown patch, matching the visibility of the previous native weight+bias patch
+representation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+import comfy.patcher_extension
+
+
+@dataclass(frozen=True)
+class _LoRAIntrospectionAdapter:
+    """Minimal classic-LoRA descriptor; never participates in model execution."""
+
+    up: torch.Tensor
+    down: torch.Tensor
+
+    name = "lora"
+
+    @property
+    def weights(self):
+        # Spectrum/Comfy classic LoRA metadata convention:
+        # (up, down, alpha, mid, dora_scale, reshape).
+        # Runtime strength is carried separately by the registry value, so alpha
+        # is rank and contributes no additional scale.
+        rank = int(self.down.shape[0])
+        return (self.up, self.down, float(rank), None, None, None)
+
+
+@dataclass(frozen=True)
+class _BiasIntrospectionAdapter:
+    """Descriptor for a runtime constant offset that is not a weight LoRA."""
+
+    offset: torch.Tensor
+
+    name = "vdn_runtime_bias"
+
+    @property
+    def weights(self):
+        return (self.offset,)
+
+
+class _RuntimeAdapterRegistry:
+    """Comfy-manager-shaped read-only metadata captured by an injection closure."""
+
+    def __init__(self, adapters: dict[str, tuple[Any, float]]):
+        self.adapters = adapters
+
+
+def _metadata_key(
+    adapters: dict[str, tuple[Any, float]],
+    base_key: str,
+    ordinal: int,
+) -> str:
+    if ordinal == 0 and base_key not in adapters:
+        return base_key
+    suffix = ordinal
+    while True:
+        candidate = f"{base_key}#vdn-runtime-{suffix}"
+        if candidate not in adapters:
+            return candidate
+        suffix += 1
+
+
+def _build_runtime_adapter_registry(
+    terms_by_module,
+    bias_terms_by_module=None,
+) -> _RuntimeAdapterRegistry:
+    """Build zero-copy introspection metadata for the active runtime residuals."""
+    bias_terms_by_module = bias_terms_by_module or {}
+    adapters: dict[str, tuple[Any, float]] = {}
+
+    for module in sorted(terms_by_module):
+        base_key = f"diffusion_model.{module}.weight"
+        for ordinal, (down, up, scale) in enumerate(terms_by_module[module]):
+            resolved_scale = float(scale)
+            if resolved_scale == 0.0:
+                continue
+            key = _metadata_key(adapters, base_key, ordinal)
+            adapters[key] = (
+                _LoRAIntrospectionAdapter(up=up, down=down),
+                resolved_scale,
+            )
+
+    for module in sorted(bias_terms_by_module):
+        base_key = f"diffusion_model.{module}.bias"
+        for ordinal, (offset, scale) in enumerate(bias_terms_by_module[module]):
+            resolved_scale = float(scale)
+            if resolved_scale == 0.0:
+                continue
+            key = _metadata_key(adapters, base_key, ordinal)
+            adapters[key] = (
+                _BiasIntrospectionAdapter(offset=offset),
+                resolved_scale,
+            )
+
+    return _RuntimeAdapterRegistry(adapters)
+
+
+def _wrap_injection_with_introspection(
+    injection,
+    registry: _RuntimeAdapterRegistry,
+):
+    """Delegate an injection unchanged while making ``registry`` introspectable."""
+
+    def inject(model_patcher):
+        # Deliberate closure capture.  Model-aware consumers can inspect this
+        # manager-shaped metadata before sampling; runtime execution remains owned
+        # entirely by the delegated injection.
+        _ = registry
+        return injection.inject(model_patcher)
+
+    def eject(model_patcher):
+        _ = registry
+        return injection.eject(model_patcher)
+
+    return comfy.patcher_extension.PatcherInjection(inject=inject, eject=eject)
+
+
+def install_runtime_introspection_bridge() -> None:
+    """Wrap VDN's post-forward injection installer once per Python process."""
+    from . import apply as apply_module
+
+    current = apply_module._install_post_forward_injection
+    if getattr(current, "_vdn_runtime_introspection_bridge", False):
+        return
+
+    original = current
+
+    def install(new_model, dm, terms_by_module, bias_terms_by_module=None):
+        count = original(
+            new_model,
+            dm,
+            terms_by_module,
+            bias_terms_by_module,
+        )
+        if not count:
+            return count
+
+        registry = _build_runtime_adapter_registry(
+            terms_by_module,
+            bias_terms_by_module,
+        )
+        if not registry.adapters:
+            return count
+
+        injections = list((getattr(new_model, "injections", {}) or {}).get("vdn_lora", ()))
+        if not injections:
+            return count
+        new_model.set_injections(
+            "vdn_lora",
+            [
+                _wrap_injection_with_introspection(injection, registry)
+                for injection in injections
+            ],
+        )
+        return count
+
+    install._vdn_runtime_introspection_bridge = True
+    install._vdn_runtime_introspection_original = original
+    apply_module._install_post_forward_injection = install


### PR DESCRIPTION
Temporary mirror PR for CI validation only. Base is the existing v1.5.2 draft head. Adds read-only runtime-adapter introspection metadata so model-aware consumers can see the non-mutating post-forward VDN LoRAs and projected curve-AdaLN constant terms without changing execution ownership. This PR will be closed after validation and squashed into the existing draft PR branch.