### PR TITLE
Rename repository references for Plus fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ComfyUI-VDN-H3
+# ComfyUI-VDN-H3-Plus
+
+> **Plus fork:** This is the `xmarre` maintained Plus fork of [Saganaki22/ComfyUI-VDN-H3](https://github.com/Saganaki22/ComfyUI-VDN-H3). It preserves the upstream project's foundation while carrying additional features, integrations, fixes, and behavior that may intentionally diverge from upstream.
 
 A ComfyUI port of the released [OpenVDN VDN-H3](https://github.com/OpenVDN/vdn-minimax-h3) hybrid-attention architecture for ComfyUI's native MiniMax-H3 model.
 
@@ -10,7 +12,7 @@ This xmarre fork keeps the released VDN checkpoint/math contract while adding cu
 
 ```bash
 cd ComfyUI/custom_nodes
-git clone https://github.com/xmarre/ComfyUI-VDN-H3.git
+git clone https://github.com/xmarre/ComfyUI-VDN-H3-Plus.git ComfyUI-VDN-H3
 ```
 
 Restart ComfyUI.
@@ -177,6 +179,6 @@ CPU/oracle CI validates numerical and ownership contracts. The complete stacked 
 
 - OpenVDN reference implementation: https://github.com/OpenVDN/vdn-minimax-h3
 - Original ComfyUI port: https://github.com/Saganaki22/ComfyUI-VDN-H3
-- This maintained fork: https://github.com/xmarre/ComfyUI-VDN-H3
+- This maintained fork: https://github.com/xmarre/ComfyUI-VDN-H3-Plus
 
 Repository code is distributed under [Apache-2.0](LICENSE). Third-party model weights and repositories retain their own licenses. See [NOTICE](NOTICE) for attribution details.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,4 +1,6 @@
-# ComfyUI-VDN-H3 — MiniMax-H3 的 VDN-H3
+# ComfyUI-VDN-H3-Plus — MiniMax-H3 的 VDN-H3
+
+> **Plus 分支：** 这是 `xmarre` 维护的 [Saganaki22/ComfyUI-VDN-H3](https://github.com/Saganaki22/ComfyUI-VDN-H3) Plus 分支。它保留上游项目基础，同时维护可能有意与上游不同的功能、集成和修复。
 
 <img width="1039" height="505" alt="VDN-H3" src="https://github.com/user-attachments/assets/ab4c1691-bff5-46fe-8b3e-635429b0700f" />
 
@@ -30,7 +32,7 @@ Advanced 节点默认 `architecture_mode=checkpoint`。只有显式选择 `overr
 
 ```bash
 cd ComfyUI/custom_nodes
-git clone https://github.com/Saganaki22/ComfyUI-VDN-H3
+git clone https://github.com/xmarre/ComfyUI-VDN-H3-Plus.git ComfyUI-VDN-H3
 ```
 
 保持官方目录结构下载到 `ComfyUI/models/vdn/`：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Repository = "https://github.com/xmarre/ComfyUI-VDN-H3"
-Issues = "https://github.com/xmarre/ComfyUI-VDN-H3/issues"
+Repository = "https://github.com/xmarre/ComfyUI-VDN-H3-Plus"
+Issues = "https://github.com/xmarre/ComfyUI-VDN-H3-Plus/issues"
 Upstream = "https://github.com/Saganaki22/ComfyUI-VDN-H3"
 OpenVDN = "https://github.com/OpenVDN/vdn-minimax-h3"
 


### PR DESCRIPTION
Post-rename metadata migration for the maintained Plus fork. Updates canonical repository links and fork-facing documentation while preserving stable package, node, workflow, release-archive, and local-install identifiers.