### PR TITLE
Expose composable VDN softmax domains to optional attention providers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to Comfy registry
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'xmarre' }}
+    env:
+      REGISTRY_ACCESS_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Publish Custom Node
+        if: ${{ env.REGISTRY_ACCESS_TOKEN != '' }}
+        uses: Comfy-Org/publish-node-action@0eb6cd742945443bee7f79eeddd4f732780029a1 # v1
+        with:
+          personal_access_token: ${{ env.REGISTRY_ACCESS_TOKEN }}
+
+      - name: Registry token unavailable
+        if: ${{ env.REGISTRY_ACCESS_TOKEN == '' }}
+        shell: bash
+        run: |
+          echo "::warning::REGISTRY_ACCESS_TOKEN is not configured for this repository; skipping Comfy Registry publication."

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,92 +1,78 @@
-# ComfyUI-VDN-H3 v1.5.2
+# ComfyUI-VDN-H3 v1.5.3
 
-v1.5.2 is the production-correctness repair for VDN bypass on the stacked quantized MiniMax-H3 workflow. It replaces the remaining VDN-owned mutable/weight-materializing bypass paths with non-mutating runtime residuals, fixes cross-stream prefetch lifetime under `cudaMallocAsync`, and restores the released exact-SDPA semantics for retained VDN local-window attention.
+v1.5.3 adds the composable VDN softmax-provider API used by ComfyUI-Sol-H3 v0.1.0, removes the historical square-Q compatibility cost for rectangular providers, and includes the post-v1.5.2 setup/documentation fixes for INT8 ConvRot stages and pruned AdaLN affine sidecars.
 
-## Runtime-bypass ownership
+## VDN softmax-provider API v3
 
-- Ordinary VDN LoRA residuals use PyTorch forward **post-hooks**.
-- VDN does **not** replace, splice, save, or restore `module.forward`.
-- VDN does **not** use `ModelPatcher.weight_function` / `add_weight_wrapper`.
-- One post-hook is registered per affected module, with all VDN terms fused into one exact low-rank residual for that module.
-- Registration handles are generation-owned across clone-shared models: a newer VDN clone replaces the old registration, while stale ejects cannot remove the newer generation.
-- Independently managed Comfy `BypassForwardHook` providers remain outside VDN's ownership; VDN never enters their mutable forward chain.
-- Fused INT8 `mlp.fc2` targets retain native Comfy patch ownership because the H3 fused path bypasses `module.forward`.
+The preferred provider contract is:
 
-This supersedes both failed v1.5.x bypass topologies: the v1.5.0 runtime weight-wrapper path and the v1.5.1 VDN-owned mutable `BypassForwardHook` chain.
-
-## Pruned / curve AdaLN bypass
-
-The exact pruning affine remains:
-
-```text
-dense(t) ≈ mean + curve(t) @ basis
-A_pruned   = A @ basis.T
-bias_delta = B @ (A @ mean)
+```python
+provider(
+    native, q, k, v,
+    *, kind, scale, square_aligned=False, sink_rows=0,
+)
 ```
 
-In `bypass`, the projected low-rank curve-coordinate residual and required constant bias are added after `adaln_proj.linear` without mutating the pruned base AdaLN weight or bias. In `merge`, the exact projected weight+bias terms continue to use ordinary native Comfy patches.
+For grouped local attention:
 
-This removes the remaining bypass-mode base-weight materialization that was still present in the first v1.5.2 candidate.
+- `q` contains only the VDN query rows actually requested by the trained local operator;
+- `k/v` remain VDN's exact already-restricted K/V domain and ordering;
+- `sink_rows` identifies the leading global/prefix K/V rows;
+- VDN retains ownership of window membership, global/anchor operations, learned softmax gate, learned linear complement and output projection.
 
-## Adapter staging
+Dispatch remains `v3 -> v2 -> v1 -> native`. The v2-only `square_q` / `query_positions` payload is now lazy and is built only when an actual v2-only provider is selected. Masked Flex remains VDN-native.
 
-Runtime VDN factors are staged synchronously onto the intended compute device when the VDN `PatcherInjection` is injected, before the first H3 module forward. Ordinary VDN post-hooks therefore do not perform their normal adapter H2D setup during the first model call. An unexpected device/dtype change retains a synchronous correctness fallback.
+`vdn_attention_preprocess_v1` also runs once on the complete post-RoPE packed Q/K/V tensors before grouped row gathering, allowing composable transforms such as Untwisting RoPE to retain original packed-row semantics without being applied twice.
 
-## `cudaMallocAsync` prefetch lifetime
+## Production result with Sol-H3 v0.1.0
 
-VDN's one-block branch prefetch allocates/copies branch weights on a producer CUDA stream and consumes them on the model stream. v1.5.2 records the actual consumer stream for every returned prefetched tensor and for quantized backing/scale tensors under both the native allocator and `cudaMallocAsync`.
+The released [ComfyUI-Sol-H3 v0.1.0](https://github.com/xmarre/ComfyUI-Sol-H3/releases/tag/v0.1.0) production stack on RTX PRO 6000 Blackwell confirms API v3 is active and direct rectangular VDN execution is 1:1 in requested/kernel Q rows:
 
-This avoids premature storage reuse across the producer/consumer stream boundary while retaining the existing bounded one-block prefetch architecture.
+| Stage | Rectangular SOL calls | Requested Q rows | Kernel Q rows | Square expansion |
+|---|---:|---:|---:|---:|
+| Native low | 1,584 | 3,744,000 | 3,744,000 | 0 |
+| Native high | 1,056 | 4,972,800 | 4,972,800 | 0 |
+| Later native high | 1,248 | 5,967,360 | 5,967,360 | 0 |
 
-## Exact VDN local-window attention
+The old v2 compatibility bridge expanded Q kernel work by roughly **4.4–5.4x** in affected stages. v1.5.3 removes that provider-side expansion without broadening VDN's attention domain or changing its trained gating/output semantics.
 
-A separate reconciliation audit found that retained grouped-window execution had started forwarding model-level `transformer_options` into VDN's local-window SDPA helper. That was semantic drift: the released VDN local-window operator is exact SDPA, while Sage/Kitchen/model-level attention overrides belong to the native/base attention path.
+Flow's separate external mixed-grid API-2 route remained direct at `144` SOL calls and `6,270,480` requested/kernel Q rows 1:1. The final Spectrum schedule was:
 
-v1.5.2 therefore deliberately ignores model-level attention overrides for retained VDN local windows and passes `None` to the local `_sdpa` calls. Regression coverage verifies both no override leakage and numerical parity with the exact grouped-window reference path.
+```text
+sampler_logical_calls       18
+transformer_actual_nfe      14
+spectrum_forecast_calls      4
 
-## Model-aware runtime metadata
+low:    8 actual / 2 forecast
+high:   4 actual / 2 forecast
+probe:  2 actual / 0 forecast
+```
 
-Read-only, zero-copy runtime adapter descriptors remain published for model-aware consumers such as Spectrum. They expose the effective runtime LoRA and constant-offset perturbations without taking execution ownership, changing adapter math, or mutating `module.forward`.
+Those counters validate composition across VDN, Sol-H3, Spectrum, Untwist, Diff-Aid and Flow. They do not transfer ownership of Flow's external route or Spectrum's forecast policy to VDN.
+
+## INT8 ConvRot stage setup
+
+The documentation now leads users to the existing pre-quantized INT8 ConvRot VDN stage while retaining the in-repository converter as the reproducible path for building a supported stage directly from the official OpenVDN checkpoint. The recommended Ref-Delta INT8 ConvRot base and auto-discovery behavior are clarified.
+
+This is documentation/package guidance around functionality already present in the repository; it does not introduce a second incompatible VDN model format.
+
+## Pruned / curve AdaLN affine setup
+
+Standard Comfy-Org `*_pruned_*` MiniMax-H3 checkpoints do not contain `adaln_basis` / `adaln_mean`, so the extractor no longer instructs users to derive those auxiliaries from files that cannot provide them. The docs point to the matching published FL2VA/Ref2VA affine sidecars, and the extraction tool now fails with actionable guidance when those tensors are absent.
+
+## Relationship to PR #8
+
+The separate PR #8 audio-fidelity experiment remains unreleased and semantically unvalidated. v1.5.3 does **not** include or depend on that experiment. The softmax-provider work lives outside `vdn_h3/hybrid.py`, so #8 may still be stacked independently for research without being a prerequisite for this release.
 
 ## Validation
 
-PR #4's final pre-release head passed CI run **232**, including current-Comfy smoke, pinned Comfy/OpenVDN oracle coverage, bypass lifecycle/math regressions, projected curve-AdaLN coverage, allocator/prefetch lifetime checks, runtime introspection, and exact retained-window attention tests.
+- Provider tests cover v1/v2/v3 dispatch, restricted-domain equivalence, lazy v2 construction, direct rectangular v3 routing and full-domain preprocessing order.
+- The normal VDN CI lanes retain pinned Comfy/OpenVDN oracle coverage, current-Comfy smoke and legacy workflow migration.
+- Sol-H3 v0.1.0's pinned native-interop suite exercised this exact VDN provider contract together with Untwist, Spectrum, Diff-Aid and Flow.
+- Real SM120 production execution established the row-accounting and 18/14/4 schedule above with zero VDN square-Q expansion.
 
-The corrected production RTX PRO 6000 workflow was then re-run on current ComfyUI with the intended Untwist RoPE configuration (`high_scale_end=1.00`) and completed successfully. The release acceptance criteria are satisfied:
-
-- no CUDA illegal-memory-access regression;
-- normal artifact-free decoded video quality in the production stack.
-
-No speed or VRAM claim is inferred from the CPU/oracle suite; historical benchmark numbers remain historical until separately re-measured.
-
-# ComfyUI-VDN-H3 v1.5.1
-
-v1.5.1 is a hotfix for a production regression introduced by v1.5.0's `lora_mode=bypass` implementation.
-
-## Fixed: stacked runtime adapters on quantized H3
-
-v1.5.0 moved VDN bypass adapters from Comfy's activation-side `BypassForwardHook` mechanism to `ModelPatcher.add_weight_wrapper()` / `weight_function`. On quantized MiniMax-H3 layers, a weight function forces Comfy through a copied/dequantized compute-weight path.
-
-In the production RTX PRO 6000 workflow using:
-
-- an INT8 ConvRot MiniMax-H3 base;
-- VDN `lora_mode=bypass`;
-- an independent runtime-bypass DoRA/LoRA provider on the same H3 modules;
-- `cudaMallocAsync`;
-- Continuum + Flow Mixed-Grid + Spectrum/SA-PECE;
-
-the first actual H3 evaluation hard-aborted with `CUDA error: an illegal memory access was encountered`. The fatal Python stack was inside the external Comfy `BypassForwardHook`/LoRA `F.linear` chain. CUDA errors are asynchronous, so that stack alone does not identify the exact originating kernel.
-
-v1.5.1 restored the older VDN `BypassForwardHook` architecture, including stack-safe linked-list insertion/removal. A later production run showed that this was not sufficient: the same stacked workflow still aborted. v1.5.1 is therefore superseded by the v1.5.2 work above.
-
-## Pruned / curve AdaLN behavior
-
-The v1.5 exact pruning-affine work was retained. Full-width released AdaLN LoRAs were projected through the resolved `adaln_basis` + `adaln_mean` pair. v1.5.1 materialized those projected curve weight/bias terms as ordinary Comfy patches in both adapter modes; the revised v1.5.2 bypass path no longer does so.
+v1.5.2's non-mutating bypass ownership, pruned-AdaLN runtime residual math, `cudaMallocAsync` prefetch lifetime fix, exact retained-window SDPA semantics and model-aware metadata remain unchanged.
 
 ---
 
-# ComfyUI-VDN-H3 v1.5.0
-
-v1.5.0 was the correctness/lifecycle and Flow-interoperability release of the xmarre fork. It added the mixed-grid API used by MiniMax-H3 Flow-Aligned Regenerate, current pruned/INT8 MiniMax-H3 support, exact curve-AdaLN projection, branch/runtime lifecycle hardening, upstream v1.4.3 reconciliation, and backwards-compatible Advanced-node workflow migration.
-
-Its `lora_mode=bypass` weight-wrapper implementation is superseded because of the stacked runtime-adapter regression described above. `merge` behavior was not implicated.
+Previous release notes through v1.5.2 are preserved verbatim in `docs/RELEASE_NOTES_v1.5.2_AND_EARLIER.md`.

--- a/docs/RELEASE_NOTES_v1.5.2_AND_EARLIER.md
+++ b/docs/RELEASE_NOTES_v1.5.2_AND_EARLIER.md
@@ -1,0 +1,92 @@
+# ComfyUI-VDN-H3 v1.5.2
+
+v1.5.2 is the production-correctness repair for VDN bypass on the stacked quantized MiniMax-H3 workflow. It replaces the remaining VDN-owned mutable/weight-materializing bypass paths with non-mutating runtime residuals, fixes cross-stream prefetch lifetime under `cudaMallocAsync`, and restores the released exact-SDPA semantics for retained VDN local-window attention.
+
+## Runtime-bypass ownership
+
+- Ordinary VDN LoRA residuals use PyTorch forward **post-hooks**.
+- VDN does **not** replace, splice, save, or restore `module.forward`.
+- VDN does **not** use `ModelPatcher.weight_function` / `add_weight_wrapper`.
+- One post-hook is registered per affected module, with all VDN terms fused into one exact low-rank residual for that module.
+- Registration handles are generation-owned across clone-shared models: a newer VDN clone replaces the old registration, while stale ejects cannot remove the newer generation.
+- Independently managed Comfy `BypassForwardHook` providers remain outside VDN's ownership; VDN never enters their mutable forward chain.
+- Fused INT8 `mlp.fc2` targets retain native Comfy patch ownership because the H3 fused path bypasses `module.forward`.
+
+This supersedes both failed v1.5.x bypass topologies: the v1.5.0 runtime weight-wrapper path and the v1.5.1 VDN-owned mutable `BypassForwardHook` chain.
+
+## Pruned / curve AdaLN bypass
+
+The exact pruning affine remains:
+
+```text
+dense(t) ≈ mean + curve(t) @ basis
+A_pruned   = A @ basis.T
+bias_delta = B @ (A @ mean)
+```
+
+In `bypass`, the projected low-rank curve-coordinate residual and required constant bias are added after `adaln_proj.linear` without mutating the pruned base AdaLN weight or bias. In `merge`, the exact projected weight+bias terms continue to use ordinary native Comfy patches.
+
+This removes the remaining bypass-mode base-weight materialization that was still present in the first v1.5.2 candidate.
+
+## Adapter staging
+
+Runtime VDN factors are staged synchronously onto the intended compute device when the VDN `PatcherInjection` is injected, before the first H3 module forward. Ordinary VDN post-hooks therefore do not perform their normal adapter H2D setup during the first model call. An unexpected device/dtype change retains a synchronous correctness fallback.
+
+## `cudaMallocAsync` prefetch lifetime
+
+VDN's one-block branch prefetch allocates/copies branch weights on a producer CUDA stream and consumes them on the model stream. v1.5.2 records the actual consumer stream for every returned prefetched tensor and for quantized backing/scale tensors under both the native allocator and `cudaMallocAsync`.
+
+This avoids premature storage reuse across the producer/consumer stream boundary while retaining the existing bounded one-block prefetch architecture.
+
+## Exact VDN local-window attention
+
+A separate reconciliation audit found that retained grouped-window execution had started forwarding model-level `transformer_options` into VDN's local-window SDPA helper. That was semantic drift: the released VDN local-window operator is exact SDPA, while Sage/Kitchen/model-level attention overrides belong to the native/base attention path.
+
+v1.5.2 therefore deliberately ignores model-level attention overrides for retained VDN local windows and passes `None` to the local `_sdpa` calls. Regression coverage verifies both no override leakage and numerical parity with the exact grouped-window reference path.
+
+## Model-aware runtime metadata
+
+Read-only, zero-copy runtime adapter descriptors remain published for model-aware consumers such as Spectrum. They expose the effective runtime LoRA and constant-offset perturbations without taking execution ownership, changing adapter math, or mutating `module.forward`.
+
+## Validation
+
+PR #4's final pre-release head passed CI run **232**, including current-Comfy smoke, pinned Comfy/OpenVDN oracle coverage, bypass lifecycle/math regressions, projected curve-AdaLN coverage, allocator/prefetch lifetime checks, runtime introspection, and exact retained-window attention tests.
+
+The corrected production RTX PRO 6000 workflow was then re-run on current ComfyUI with the intended Untwist RoPE configuration (`high_scale_end=1.00`) and completed successfully. The release acceptance criteria are satisfied:
+
+- no CUDA illegal-memory-access regression;
+- normal artifact-free decoded video quality in the production stack.
+
+No speed or VRAM claim is inferred from the CPU/oracle suite; historical benchmark numbers remain historical until separately re-measured.
+
+# ComfyUI-VDN-H3 v1.5.1
+
+v1.5.1 is a hotfix for a production regression introduced by v1.5.0's `lora_mode=bypass` implementation.
+
+## Fixed: stacked runtime adapters on quantized H3
+
+v1.5.0 moved VDN bypass adapters from Comfy's activation-side `BypassForwardHook` mechanism to `ModelPatcher.add_weight_wrapper()` / `weight_function`. On quantized MiniMax-H3 layers, a weight function forces Comfy through a copied/dequantized compute-weight path.
+
+In the production RTX PRO 6000 workflow using:
+
+- an INT8 ConvRot MiniMax-H3 base;
+- VDN `lora_mode=bypass`;
+- an independent runtime-bypass DoRA/LoRA provider on the same H3 modules;
+- `cudaMallocAsync`;
+- Continuum + Flow Mixed-Grid + Spectrum/SA-PECE;
+
+the first actual H3 evaluation hard-aborted with `CUDA error: an illegal memory access was encountered`. The fatal Python stack was inside the external Comfy `BypassForwardHook`/LoRA `F.linear` chain. CUDA errors are asynchronous, so that stack alone does not identify the exact originating kernel.
+
+v1.5.1 restored the older VDN `BypassForwardHook` architecture, including stack-safe linked-list insertion/removal. A later production run showed that this was not sufficient: the same stacked workflow still aborted. v1.5.1 is therefore superseded by the v1.5.2 work above.
+
+## Pruned / curve AdaLN behavior
+
+The v1.5 exact pruning-affine work was retained. Full-width released AdaLN LoRAs were projected through the resolved `adaln_basis` + `adaln_mean` pair. v1.5.1 materialized those projected curve weight/bias terms as ordinary Comfy patches in both adapter modes; the revised v1.5.2 bypass path no longer does so.
+
+---
+
+# ComfyUI-VDN-H3 v1.5.0
+
+v1.5.0 was the correctness/lifecycle and Flow-interoperability release of the xmarre fork. It added the mixed-grid API used by MiniMax-H3 Flow-Aligned Regenerate, current pruned/INT8 MiniMax-H3 support, exact curve-AdaLN projection, branch/runtime lifecycle hardening, upstream v1.4.3 reconciliation, and backwards-compatible Advanced-node workflow migration.
+
+Its `lora_mode=bypass` weight-wrapper implementation is superseded because of the stacked runtime-adapter regression described above. `merge` behavior was not implicated.

--- a/docs/SOFTMAX_PROVIDER.md
+++ b/docs/SOFTMAX_PROVIDER.md
@@ -1,0 +1,84 @@
+# Optional attention subcall providers
+
+Production companion: [ComfyUI-Sol-H3 v0.1.0](https://github.com/xmarre/ComfyUI-Sol-H3/releases/tag/v0.1.0).
+
+VDN keeps ownership of its trained window/global/anchor geometry, learned softmax gate, output projection and learned linear complement. External providers can only operate on domains VDN has already selected.
+
+The provider contract is implemented in grouped retained attention rather than `vdn_h3/hybrid.py`. It therefore remains independent of the separate experimental audio-fidelity work in PR #8; #8 is not required for this provider contract or for v1.5.3.
+
+## v1
+
+`transformer_options["vdn_softmax_provider_v1"]` remains supported:
+
+```python
+provider(native, q, k, v, *, kind, scale, square_aligned=False)
+```
+
+It returns `[query_rows, heads, head_dim]` with unchanged dtype/device. `native()` executes the original operation. `square_aligned=True` means Q and KV already describe the same ordered row domain, not merely equal tensor dimensions.
+
+Normal MiniMax-H3 VDN windows include packed non-video/global rows in KV. Their requested video Q rows are therefore usually rectangular against the restricted KV domain.
+
+## v2 square-domain compatibility
+
+`transformer_options["vdn_softmax_provider_v2"]` remains available for square-QKV-only providers:
+
+```python
+provider(
+    native, q, k, v,
+    *, kind, scale, square_aligned=False,
+    square_q=None, query_positions=None, sink_rows=0,
+)
+```
+
+For a grouped local call, VDN constructs K/V in its existing order `[global_rows, permitted_window_rows]`. `square_q`, when supplied, contains the real Q rows from those exact same packed indices and in the same order. `query_positions` maps the original requested Q rows into that square domain.
+
+This path does not broaden VDN attention, but it evaluates extra disposable Q rows and is retained only for compatibility with providers that genuinely require square Q/K/V.
+
+## v3 direct rectangular contract
+
+`transformer_options["vdn_softmax_provider_v3"]` is the preferred contract for providers that accept rectangular attention:
+
+```python
+provider(
+    native, q, k, v,
+    *, kind, scale, square_aligned=False, sink_rows=0,
+)
+```
+
+For local calls, `q` contains only the requested VDN query rows while `k/v` contain the exact already-restricted VDN K/V domain. `sink_rows` is the leading global/prefix K/V row count. No `square_q` or `query_positions` payload is constructed.
+
+Dispatch order is v3, then v2, then v1. Sol-H3 v0.1.0 publishes v3, so production rectangular SOL no longer pays the v2 square-Q gather/allocation. v2 construction is lazy and occurs only when an actual v2-only provider is installed.
+
+Global and anchor operations remain separate. Masked Flex remains VDN-native; if Flex falls back to grouped, that grouped execution can consume the explicit provider contract.
+
+## Full-domain QKV preprocessing
+
+`transformer_options["vdn_attention_preprocess_v1"]` is an optional shape-preserving preprocessing callable:
+
+```python
+preprocess(q, k, v, *, heads, transformer_options)
+```
+
+For grouped execution it runs once on the complete post-RoPE packed tensors inside `window_softmax_grouped_runtime`, before VDN gathers local row domains. This is required for transforms such as Untwist whose metadata uses original packed-row coordinates. Shape, dtype and device must remain unchanged.
+
+Generic model-level dense attention overrides still do not automatically leak into VDN's trained local operator. The explicit provider/preprocess contracts define composition instead.
+
+## Optional stacking with PR #8
+
+The unreleased PR #8 audio-fidelity experiment owns separate hybrid/audio/training behavior. This provider work does not edit `vdn_h3/hybrid.py` and can be stacked with #8 for experimentation, but v1.5.3 does not depend on #8 and does not include its unvalidated semantic experiment.
+
+## Validation and production evidence
+
+The provider suite checks v1/v2/v3 dispatch, restricted-domain equivalence, lazy v2 square mapping, direct rectangular v3 routing, and full-domain preprocessing before grouped row gathering. The normal VDN CI lanes cover the pinned Comfy/OpenVDN oracle, current-Comfy smoke and legacy workflow migration.
+
+The released Sol-H3 v0.1.0 production stack on RTX PRO 6000 Blackwell confirms direct v3 routing with no VDN square-Q expansion:
+
+| Stage | Rectangular SOL calls | Requested Q rows | Kernel Q rows | Square expansion |
+|---|---:|---:|---:|---:|
+| Native low | 1,584 | 3,744,000 | 3,744,000 | 0 |
+| Native high | 1,056 | 4,972,800 | 4,972,800 | 0 |
+| Later native high | 1,248 | 5,967,360 | 5,967,360 | 0 |
+
+The historical v2 compatibility bridge expanded Q kernel work by roughly 4.4–5.4x in affected stages. v3 removes that expansion without changing VDN's K/V membership, learned gate, linear complement, output projection or global/anchor ownership.
+
+Flow's separate external mixed-grid API-2 route also remained direct at 144 SOL calls / 6,270,480 requested and kernel Q rows 1:1. Spectrum retained 18 logical calls / 14 actual transformer NFEs / 4 forecasts in the final stack. These results validate provider composition; they are not a claim that VDN itself owns Flow's external route or Spectrum's forecast policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-vdn-h3"
-version = "1.5.2"
+version = "1.5.3"
 description = "VDN-H3 hybrid attention for ComfyUI MiniMax-H3 with pre-quantized or self-built INT8 ConvRot VDN stages"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_softmax_provider.py
+++ b/tests/test_softmax_provider.py
@@ -1,0 +1,150 @@
+import torch
+
+from vdn_h3 import retained, window
+from vdn_h3.softmax_provider import (
+    KEY,
+    KEY_V2,
+    KEY_V3,
+    PREPROCESS_KEY,
+    PROVIDER_API_VERSION,
+    dispatch,
+    preprocess,
+)
+
+
+def test_grouped_v1_provider_receives_only_existing_window_domains():
+    torch.manual_seed(7)
+    q, k, v = (torch.randn(13, 2, 4) for _ in range(3))
+    bounds = window.window_bounds(4, 0, 2)
+    observed = []
+    def provider(native, q, k, v, **contract):
+        observed.append((q.shape[0], k.shape[0], contract))
+        return native()
+    def forbidden(*a, **kw):
+        raise AssertionError("model-level dense override leaked into VDN local attention")
+    options = {KEY: provider, "optimized_attention_override": forbidden}
+    for anchor in ("none", "rows", "columns", "both"):
+        got = retained.window_softmax_grouped_runtime(q, k, v, 2, 10, 4, 2, bounds, .5,
+                                                     anchor_frames=anchor, transformer_options=options)
+        want = window.window_softmax_grouped(q, k, v, 2, 10, 4, 2, bounds, .5, anchor_frames=anchor)
+        torch.testing.assert_close(got, want, rtol=0, atol=0)
+    assert any(c[2]["kind"] == "local" and c[0] < c[1] for c in observed)
+    assert any(c[2]["kind"] == "global" for c in observed)
+    assert any(c[2]["kind"] == "anchor" for c in observed)
+    assert not any(c[2]["square_aligned"] for c in observed)
+
+
+def test_square_local_v1_contract_requires_matching_row_domain():
+    q, k, v = (torch.randn(8, 2, 4) for _ in range(3))
+    bounds = window.window_bounds(4, 0, 2)
+    seen = []
+    def provider(native, q, k, v, **contract):
+        seen.append(contract)
+        assert contract["square_aligned"]
+        assert q.shape == k.shape == v.shape == (4, 2, 4)
+        return native()
+    got = retained.window_softmax_grouped_runtime(q, k, v, 0, 8, 4, 2, bounds, .5,
+                                                 transformer_options={KEY: provider})
+    want = window.window_softmax_grouped(q, k, v, 0, 8, 4, 2, bounds, .5)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+    assert len(seen) == 2
+
+
+def test_v2_square_domain_matches_native_rectangular_attention():
+    torch.manual_seed(17)
+    q, k, v = (torch.randn(13, 2, 4) for _ in range(3))
+    bounds = window.window_bounds(4, 0, 2)
+    seen = []
+
+    def provider(native, q, k, v, **contract):
+        if contract["kind"] != "local":
+            assert contract["square_q"] is None
+            return native()
+        square_q = contract["square_q"]
+        positions = contract["query_positions"]
+        assert square_q.shape == k.shape == v.shape
+        assert positions.dtype == torch.long and positions.device == q.device
+        torch.testing.assert_close(square_q.index_select(0, positions), q, rtol=0, atol=0)
+        assert contract["sink_rows"] == 5
+        seen.append((q.shape[0], square_q.shape[0]))
+        square_out = window._sdpa(square_q, k, v, contract["scale"], None)
+        return square_out.index_select(0, positions)
+
+    got = retained.window_softmax_grouped_runtime(
+        q, k, v, 2, 10, 4, 2, bounds, .5,
+        transformer_options={KEY_V2: provider})
+    want = window.window_softmax_grouped(q, k, v, 2, 10, 4, 2, bounds, .5)
+    torch.testing.assert_close(got, want, rtol=1e-5, atol=1e-6)
+    assert seen and all(requested < square for requested, square in seen)
+
+
+def test_v3_direct_rectangular_domain_avoids_square_payload():
+    assert PROVIDER_API_VERSION == 3
+    torch.manual_seed(19)
+    q, k, v = (torch.randn(13, 2, 4) for _ in range(3))
+    bounds = window.window_bounds(4, 0, 2)
+    seen = []
+
+    def provider(native, q, k, v, **contract):
+        assert "square_q" not in contract
+        assert "query_positions" not in contract
+        if contract["kind"] == "local":
+            assert q.shape[0] < k.shape[0]
+            assert contract["sink_rows"] == 5
+            seen.append((q.shape[0], k.shape[0]))
+        return native()
+
+    got = retained.window_softmax_grouped_runtime(
+        q, k, v, 2, 10, 4, 2, bounds, .5,
+        transformer_options={KEY_V3: provider})
+    want = window.window_softmax_grouped(q, k, v, 2, 10, 4, 2, bounds, .5)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+    assert seen and all(requested < restricted_kv for requested, restricted_kv in seen)
+
+
+def test_provider_precedence_v3_then_v2_then_v1():
+    q = torch.randn(4, 2, 4)
+    calls = []
+    def v1(native, q, k, v, **contract):
+        calls.append("v1")
+        return native()
+    def v2(native, q, k, v, **contract):
+        calls.append("v2")
+        return native()
+    def v3(native, q, k, v, **contract):
+        calls.append("v3")
+        return native()
+    dispatch({KEY: v1, KEY_V2: v2, KEY_V3: v3}, lambda: q, q, q, q, kind="local", scale=.5)
+    assert calls == ["v3"]
+    calls.clear()
+    dispatch({KEY: v1, KEY_V2: v2}, lambda: q, q, q, q, kind="local", scale=.5)
+    assert calls == ["v2"]
+    calls.clear()
+    dispatch({KEY: v1}, lambda: q, q, q, q, kind="local", scale=.5)
+    assert calls == ["v1"]
+
+
+def test_full_domain_preprocess_is_shape_preserving_and_explicit():
+    q, k, v = (torch.randn(8, 2, 4) for _ in range(3))
+    original_k = k.clone()
+    calls = []
+    def transform(q, k, v, *, heads, transformer_options):
+        calls.append((heads, transformer_options["tag"]))
+        return q, k * 2, v
+    q2, k2, v2 = preprocess({PREPROCESS_KEY: transform, "tag": 9}, q, k, v, 2)
+    assert q2 is q and v2 is v
+    torch.testing.assert_close(k2, original_k * 2)
+    assert calls == [(2, 9)]
+
+
+def test_flex_contract_keeps_native_masked_operator():
+    q = torch.randn(8, 2, 4)
+    calls = []
+    def provider(native, q, k, v, **contract):
+        assert contract == {"kind": "flex_masked", "scale": .5, "square_aligned": False}
+        return native()
+    def native():
+        calls.append(True)
+        return q + 1
+    got = dispatch({KEY: provider}, native, q, q, q, kind="flex_masked", scale=.5)
+    assert torch.equal(got, q + 1) and len(calls) == 1

--- a/tests/test_softmax_provider_stack.py
+++ b/tests/test_softmax_provider_stack.py
@@ -1,0 +1,29 @@
+import torch
+
+from vdn_h3 import retained, window
+from vdn_h3.softmax_provider import PREPROCESS_KEY
+
+
+def test_grouped_runtime_preprocesses_full_domain_before_gather():
+    torch.manual_seed(29)
+    q, k, v = (torch.randn(13, 2, 4) for _ in range(3))
+    bounds = window.window_bounds(4, 0, 2)
+    seen = []
+
+    def transform(q, k, v, *, heads, transformer_options):
+        seen.append((q.shape, k.shape, v.shape, heads))
+        return q + 0.25, k, v
+
+    got = retained.window_softmax_grouped_runtime(
+        q, k, v, 2, 10, 4, 2, bounds, 0.5,
+        anchor_frames="both",
+        transformer_options={PREPROCESS_KEY: transform},
+    )
+    want = retained.window_softmax_grouped_runtime(
+        q + 0.25, k, v, 2, 10, 4, 2, bounds, 0.5,
+        anchor_frames="both",
+        transformer_options=None,
+    )
+
+    assert seen == [((13, 2, 4), (13, 2, 4), (13, 2, 4), 2)]
+    torch.testing.assert_close(got, want, rtol=0, atol=0)

--- a/vdn_h3/retained.py
+++ b/vdn_h3/retained.py
@@ -141,7 +141,9 @@ def _build_window_plan(video_start, video_end, num_frames, tokens_per_frame,
         grouped.setdefault((lo, hi), []).append(frame)
 
     groups = []
-    max_kv_rows = global_idx.numel()
+    square_aligned = []
+    global_count = global_idx.numel()
+    max_kv_rows = global_count
     for (lo, hi), frames in grouped.items():
         extra = [
             frame for frame in anchors
@@ -151,11 +153,13 @@ def _build_window_plan(video_start, video_end, num_frames, tokens_per_frame,
         win_idx = torch.cat([frame_rows(frame) for frame in key_frames])
         q_idx = torch.cat([frame_rows(frame) for frame in frames])
         groups.append((q_idx, win_idx))
-        max_kv_rows = max(max_kv_rows, global_idx.numel() + win_idx.numel())
+        square_aligned.append(global_count == 0 and frames == key_frames)
+        max_kv_rows = max(max_kv_rows, global_count + win_idx.numel())
 
     return {
         "global_idx": global_idx,
         "groups": groups,
+        "square_aligned": square_aligned,
         "anchor_slices": [
             (
                 video_start + frame * tokens_per_frame,
@@ -172,12 +176,24 @@ def window_softmax_grouped_runtime(query, key, value, video_start, video_end,
                                    anchor_frames="none", transformer_options=None):
     """Grouped exact window softmax with execution-owned plan/KV scratch reuse.
 
-    VDN's released local-window operator is exact SDPA. Model-level attention
-    overrides (Sage/Kitchen/etc.) apply to native/base attention, but must not leak
-    into VDN's trained local-window branch. ``transformer_options`` is accepted for
-    API compatibility only and deliberately ignored here.
+    VDN's native local-window operator is exact SDPA. Generic model-level dense
+    overrides do not leak into the trained local branch. Explicit v1/v2/v3 providers
+    may consume only the row domains VDN already selected. v2 receives a square-Q
+    compatibility payload only when no v3 direct-rectangular provider is installed;
+    v3 receives requested Q directly and therefore adds no square-Q gather/allocation.
     """
-    del transformer_options
+    from .softmax_provider import dispatch, has_v2, has_v3, preprocess
+
+    # This is still the complete post-RoPE packed sequence. Run explicit QKV
+    # preprocessing here, before any VDN row gathering, so transforms that depend
+    # on original packed coordinates (for example Untwist) remain well-defined.
+    query, key, value = preprocess(
+        transformer_options, query, key, value, query.shape[1])
+
+    def attend(q, k, v, kind, aligned=False, **contract):
+        return dispatch(transformer_options, lambda: W._sdpa(q, k, v, scale, None),
+                        q, k, v, kind=kind, scale=scale,
+                        square_aligned=aligned, **contract)
     heads, head_dim = query.shape[1], query.shape[2]
     seq = query.shape[0]
     resources = current_runtime_buffers()
@@ -200,8 +216,7 @@ def window_softmax_grouped_runtime(query, key, value, video_start, video_end,
     global_idx = plan["global_idx"]
     global_count = global_idx.numel()
     if global_count:
-        out[global_idx] = W._sdpa(
-            query[global_idx], key, value, scale, None)
+        out[global_idx] = attend(query[global_idx], key, value, "global")
 
     groups = plan["groups"]
     if groups:
@@ -215,24 +230,38 @@ def window_softmax_grouped_runtime(query, key, value, video_start, video_end,
         if global_count:
             torch.index_select(key, 0, global_idx, out=k_scratch[:global_count])
             torch.index_select(value, 0, global_idx, out=v_scratch[:global_count])
-        for q_idx, win_idx in groups:
+        v3 = has_v3(transformer_options)
+        v2 = not v3 and has_v2(transformer_options)
+        for group_index, (q_idx, win_idx) in enumerate(groups):
             window_rows = win_idx.numel()
+            domain_rows = global_count + window_rows
             torch.index_select(
                 key, 0, win_idx,
-                out=k_scratch[global_count:global_count + window_rows])
+                out=k_scratch[global_count:domain_rows])
             torch.index_select(
                 value, 0, win_idx,
-                out=v_scratch[global_count:global_count + window_rows])
+                out=v_scratch[global_count:domain_rows])
             q_rows = query.index_select(0, q_idx)
-            out[q_idx] = W._sdpa(
+            contract = {"sink_rows": global_count}
+            if v2:
+                # Legacy v2 square-Q compatibility is now genuinely lazy. The
+                # current Sol-H3 stack publishes v3, so this gather/allocation is
+                # absent from production rectangular dispatch.
+                domain_idx = torch.cat((global_idx, win_idx)) if global_count else win_idx
+                query_positions = torch.searchsorted(win_idx, q_idx) + global_count
+                contract.update(
+                    square_q=query.index_select(0, domain_idx),
+                    query_positions=query_positions,
+                )
+            out[q_idx] = attend(
                 q_rows,
-                k_scratch[:global_count + window_rows],
-                v_scratch[:global_count + window_rows],
-                scale,
-                None,
+                k_scratch[:domain_rows],
+                v_scratch[:domain_rows],
+                "local",
+                plan["square_aligned"][group_index],
+                **contract,
             )
 
     for start, stop in plan["anchor_slices"]:
-        out[start:stop] = W._sdpa(
-            query[start:stop], key, value, scale, None)
+        out[start:stop] = attend(query[start:stop], key, value, "anchor")
     return out

--- a/vdn_h3/softmax_provider.py
+++ b/vdn_h3/softmax_provider.py
@@ -1,0 +1,71 @@
+"""Opt-in attention subcall contracts. Generic dense overrides do not leak here.
+
+v1 providers receive the already-requested Q rows and already-restricted KV rows.
+v2 additionally receives the real square query domain aligned 1:1 with those KV
+rows plus a mapping back to the original requested rows. Providers may evaluate
+extra queries to satisfy square-QKV kernels, but VDN still owns the KV domain,
+gates, projections and learned linear complement.
+
+v3 is the direct rectangular contract: providers receive only the requested Q rows,
+the already-restricted K/V rows, and the leading global/prefix K/V row count. This
+lets rectangular kernels avoid constructing the v2 square-Q compatibility payload.
+
+A separate preprocessing hook is limited to shape-preserving Q/K/V transforms and
+runs on the full post-RoPE VDN tensors before grouped-window gathering. This lets
+transforms whose metadata uses original packed-row coordinates compose without
+remapping those coordinates inside each local window.
+"""
+PROVIDER_API_VERSION = 3
+KEY = "vdn_softmax_provider_v1"
+KEY_V2 = "vdn_softmax_provider_v2"
+KEY_V3 = "vdn_softmax_provider_v3"
+PREPROCESS_KEY = "vdn_attention_preprocess_v1"
+
+
+def has_v2(options):
+    return callable((options or {}).get(KEY_V2))
+
+
+def has_v3(options):
+    return callable((options or {}).get(KEY_V3))
+
+
+def preprocess(options, q, k, v, heads):
+    provider = (options or {}).get(PREPROCESS_KEY)
+    if provider is None:
+        return q, k, v
+    shapes = (q.shape, k.shape, v.shape)
+    dtypes = (q.dtype, k.dtype, v.dtype)
+    devices = (q.device, k.device, v.device)
+    q, k, v = provider(q, k, v, heads=heads, transformer_options=options)
+    if (q.shape, k.shape, v.shape) != shapes:
+        raise RuntimeError("VDN attention preprocessing changed QKV topology")
+    if (q.dtype, k.dtype, v.dtype) != dtypes or (q.device, k.device, v.device) != devices:
+        raise RuntimeError("VDN attention preprocessing changed QKV dtype/device")
+    return q, k, v
+
+
+def dispatch(options, native, q, k, v, *, kind, scale, square_aligned=False,
+             square_q=None, query_positions=None, sink_rows=0):
+    options = options or {}
+    provider = options.get(KEY_V3)
+    if provider is not None:
+        result = provider(
+            native, q, k, v, kind=kind, scale=scale,
+            square_aligned=square_aligned, sink_rows=sink_rows)
+    else:
+        provider = options.get(KEY_V2)
+        if provider is not None:
+            result = provider(
+                native, q, k, v, kind=kind, scale=scale,
+                square_aligned=square_aligned, square_q=square_q,
+                query_positions=query_positions, sink_rows=sink_rows)
+        else:
+            provider = options.get(KEY)
+            if provider is None:
+                return native()
+            result = provider(native, q, k, v, kind=kind, scale=scale,
+                              square_aligned=square_aligned)
+    if result.shape != q.shape or result.dtype != q.dtype or result.device != q.device:
+        raise RuntimeError("VDN softmax provider returned incompatible shape/dtype/device")
+    return result


### PR DESCRIPTION
## Release candidate: v1.5.3

This PR adds VDN's composable softmax-provider API v3 on top of current `main` and is now independent of the separate unreleased audio-fidelity experiment in PR #8. It is the production companion used by [ComfyUI-Sol-H3 v0.1.0](https://github.com/xmarre/ComfyUI-Sol-H3/releases/tag/v0.1.0).

PR #8 remains draft and semantically unvalidated; **it is not included in or required by v1.5.3**. The provider work lives outside `vdn_h3/hybrid.py`, so #8 can still be stacked independently for research without becoming a release prerequisite.

## Provider API v3

Preferred contract:

```python
provider(
    native, q, k, v,
    *, kind, scale, square_aligned=False, sink_rows=0,
)
```

For grouped local attention:

- `q` contains only originally requested VDN query rows;
- `k/v` remain VDN's exact already-restricted domain in existing order;
- `sink_rows` is the leading global/prefix K/V row count;
- VDN retains learned softmax gate, linear complement, output projection and global/anchor ownership.

Dispatch remains:

```text
v3 -> v2 -> v1 -> native
```

The v2-only `square_q` / `query_positions` payload is lazy and is not built when v3 is selected. `vdn_attention_preprocess_v1` still runs once on full post-RoPE packed Q/K/V before grouped-window gathering. Masked Flex remains VDN-native.

## Production result

The released Sol-H3 v0.1.0 production stack confirms API v3 is active and native rectangular VDN attention is 1:1 requested/kernel Q rows with zero square expansion:

| Stage | Rectangular SOL calls | Requested Q rows | Kernel Q rows | Square expansion |
|---|---:|---:|---:|---:|
| Native low | 1,584 | 3,744,000 | 3,744,000 | 0 |
| Native high | 1,056 | 4,972,800 | 4,972,800 | 0 |
| Later native high | 1,248 | 5,967,360 | 5,967,360 | 0 |

The historical v2 compatibility bridge expanded Q kernel work by roughly **4.4–5.4x** in affected stages. API v3 removes that expansion without changing VDN's restricted K/V domain, learned gate, linear complement, output projection or global/anchor ownership.

Flow's separate external mixed-grid API-2 route remained direct at `144` SOL calls / `6,270,480` requested and kernel Q rows 1:1. Spectrum settled at:

```text
sampler_logical_calls       18
transformer_actual_nfe      14
spectrum_forecast_calls      4

low:    8 actual / 2 forecast
high:   4 actual / 2 forecast
probe:  2 actual / 0 forecast
```

The bypass control is 13 actual + 5 forecast; the one additional Sol actual is the legitimate first `dense -> sol` transition. No VDN ownership or history contract is weakened to remove that safety anchor.

## Other v1.5.3 release content already on current main

The release also incorporates the post-v1.5.2 user-facing setup work already merged to `main`:

- documents the existing ready-made INT8 ConvRot VDN stage while retaining the in-repo converter for users who want to build their own from official OpenVDN checkpoints;
- clarifies the recommended Ref-Delta INT8 ConvRot base and affine auto-discovery;
- documents the published FL2VA/Ref2VA pruned-AdaLN affine sidecars;
- makes the affine extractor fail with actionable guidance instead of telling users to extract missing `adaln_basis` / `adaln_mean` from standard Comfy-Org pruned checkpoints.

## Release plumbing/documentation

- `docs/SOFTMAX_PROVIDER.md` now points to released Sol-H3 v0.1.0 and records final production row accounting.
- `RELEASE_NOTES.md` contains the v1.5.3 provider/setup result; prior notes are preserved verbatim in `docs/RELEASE_NOTES_v1.5.2_AND_EARLIER.md`.
- `pyproject.toml` is bumped to `1.5.3`.
- A Comfy Registry publish workflow is added. It publishes when `REGISTRY_ACCESS_TOKEN` is available and otherwise skips explicitly without affecting the GitHub release.
- Internal mirror-branch CI triggering from the development PR was deliberately not carried into the release tree.

## Validation / topology

```text
head:    27b1bfd4da6a668fcb9bc82ef354c5c9c0217e76
parent:  25f42bd4eddaff6b96122c250ce23badbee0efd3
tree:    6063f20fd53be75d9bf66264633df400c19fdc4e
commits: 1
```

The PR is rebased cleanly onto current main, preserving the current README/AdaLN/INT8 guidance rather than overwriting it. The Sol-H3 v0.1.0 pinned native-interop suite already exercised this provider stack on CPU and the real RTX PRO 6000 production run supplied the SM120 runtime gate. Final VDN PR-head CI is the remaining merge gate.

v1.5.2's non-mutating bypass ownership, pruned-AdaLN runtime residual math, `cudaMallocAsync` prefetch lifetime fix, exact retained-window SDPA semantics and model-aware metadata remain unchanged.