### PR TITLE
Move AIMDO compiler guard from DIFFUSION_MODEL to OUTER_SAMPLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Newly created nodes still default to `architecture_mode="checkpoint"`.
 - VDN's retained local-window operator uses exact SDPA and deliberately does not inherit model-level `transformer_options` attention overrides such as Sage/Kitchen backends.
 - VDN owns the H3 attention object patch. Another extension that tries to own the same `diffusion_model.blocks.*.attn.forward` target is rejected rather than ambiguously stacked.
 - Runtime LoRA/DoRA providers using Comfy's ordinary `BypassForwardHook` mechanism may coexist with VDN bypass. VDN does not join or rewrite that provider's forward chain.
-- The AIMDO malloc-graph compatibility guard is scoped only around VDN diffusion-model execution and restores the user's compiler setting afterward.
+- The AIMDO malloc-graph compatibility guard runs at `OUTER_SAMPLE` on the VDN-patched model only, and restores the user's compiler setting afterward. It has to be that early: Comfy decides whether to open a malloc graph, and allocates its staging latents, before any `DIFFUSION_MODEL` wrapper runs, so a guard at that hook cannot prevent the compile and leaves the graph half-recorded. A run against an unpatched model is untouched, and a user-supplied `--disable-comfy-compiler` is never un-set.
 - Historical benchmark numbers in [Benchmarks.md](Benchmarks.md) predate the current lifecycle work and are not assigned to this runtime without matched measurement.
 
 ## Validation

--- a/__init__.py
+++ b/__init__.py
@@ -12,11 +12,7 @@ _PKG = os.path.dirname(__file__)
 if _PKG not in sys.path:
     sys.path.insert(0, _PKG)
 
-from vdn_h3.compiler_guard import install_layout_guard as _install_layout_guard
 from vdn_h3.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
-
-_install_layout_guard()
-del _install_layout_guard
 
 # Frontend compatibility shim for legacy ApplyVDNH3Advanced positional workflows.
 WEB_DIRECTORY = "./web"

--- a/tests/test_compiler_guard.py
+++ b/tests/test_compiler_guard.py
@@ -66,9 +66,42 @@ def test_nested_owned_guards_restore_only_after_outer_exit(monkeypatch):
     assert comfy.cli_args.args.disable_comfy_compiler is False
 
 
-def test_layout_guard_install_is_idempotent():
-    from vdn_h3 import hybrid
+def test_outer_sample_wrapper_disables_for_the_wrapped_call(monkeypatch):
+    monkeypatch.setattr(compiler_guard, "_compiler_stack_present", lambda: True)
+    comfy.cli_args.args.disable_comfy_compiler = False
+    seen = []
 
-    compiler_guard.install_layout_guard()
-    assert getattr(hybrid.make_layout_wrapper, "_vdn_compiler_guard_installed", False)
-    assert compiler_guard.install_layout_guard() is False
+    def executor(*args, **kwargs):
+        seen.append((args, kwargs,
+                     comfy.cli_args.args.disable_comfy_compiler))
+        return "out"
+
+    wrapper = compiler_guard.make_outer_sample_wrapper()
+    assert wrapper(executor, 1, 2, seed=3) == "out"
+    assert seen == [((1, 2), {"seed": 3}, True)]
+    assert comfy.cli_args.args.disable_comfy_compiler is False
+    assert compiler_guard._active_owned_guards == 0
+
+
+def test_outer_sample_wrapper_restores_after_exception(monkeypatch):
+    monkeypatch.setattr(compiler_guard, "_compiler_stack_present", lambda: True)
+    comfy.cli_args.args.disable_comfy_compiler = False
+
+    def executor(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    wrapper = compiler_guard.make_outer_sample_wrapper()
+    with pytest.raises(RuntimeError, match="boom"):
+        wrapper(executor)
+    assert comfy.cli_args.args.disable_comfy_compiler is False
+    assert compiler_guard._active_owned_guards == 0
+
+
+def test_outer_sample_wrapper_preserves_user_disabled_setting(monkeypatch):
+    monkeypatch.setattr(compiler_guard, "_compiler_stack_present", lambda: True)
+    comfy.cli_args.args.disable_comfy_compiler = True
+
+    wrapper = compiler_guard.make_outer_sample_wrapper()
+    assert wrapper(lambda: "out") == "out"
+    assert comfy.cli_args.args.disable_comfy_compiler is True
+    assert compiler_guard._active_owned_guards == 0

--- a/vdn_h3/compiler_guard.py
+++ b/vdn_h3/compiler_guard.py
@@ -12,14 +12,37 @@ possible:
   wrappers and restored in ``finally``;
 * no Comfy function is monkey-patched and no unload hook is installed.
 
-The guard is installed around VDN's own DIFFUSION_MODEL wrapper, so the switch is
-active before the native MiniMax-H3 forward asks ``model_prefetch`` whether to
-start a malloc graph and is restored immediately after that wrapped forward.
+Hook placement is not a matter of taste.  ``comfy/ldm/minimax/model.py`` reads the
+switch and opens the graph *before* it runs any DIFFUSION_MODEL wrapper::
+
+    compile_allocations = comfy.model_prefetch.malloc_graph_enabled(x[0].device)
+    if compile_allocations:
+        out = [torch.empty_like(x[0]), torch.empty_like(x[1])]
+        comfy.model_prefetch.malloc_graph_begin(self, x[0].device)
+    graph_out = ...DIFFUSION_MODEL wrappers...
+
+A guard installed at DIFFUSION_MODEL therefore flips the flag *after* the decision
+is taken and the graph is already open.  It cannot prevent the compile; all it
+achieves is silencing the per-block ``prefetch_queue_pop(..., malloc_scope="block")``
+recording at ``model.py:747`` partway through a graph that stays open and is closed
+normally, leaving a half-recorded pattern.  It also leaves the two full-size
+``empty_like`` staging latents allocated for the whole forward.
+
+The guard is therefore installed at OUTER_SAMPLE, which Comfy gathers in
+``samplers.py`` before the sampling loop begins.  That is early enough for
+``malloc_graph_enabled`` to return False at the top of every forward in the run,
+so no graph is ever opened and no staging latents are allocated.  The scope is one
+sampling run rather than one forward; that is the narrowest scope that is actually
+correct, not a widening for convenience.
+
+One asymmetry is inherent to mutating config instead of passing the CLI flag:
+``cli_args`` applies ``disable_comfy_compiler -> disable_cuda_graphs`` once at
+import time, so a runtime flip suppresses the malloc graph but not CUDA graphs.
+``malloc_graph_enabled`` is the path that matters here.
 """
 from __future__ import annotations
 
 from contextlib import contextmanager
-import functools
 import logging
 import threading
 
@@ -49,7 +72,7 @@ def _compiler_stack_present() -> bool:
 
 @contextmanager
 def disabled_for_vdn():
-    """Temporarily disable Comfy's compiler for one VDN model forward.
+    """Temporarily disable Comfy's compiler for one VDN sampling run.
 
     The CLI flag is process-global, so true concurrent non-VDN execution cannot be
     isolated by any consumer-side workaround.  Comfy's normal prompt executor is
@@ -74,7 +97,7 @@ def disabled_for_vdn():
                     _warned = True
                     _log.warning(
                         "[vdn] this Comfy build's AIMDO model compiler is incompatible "
-                        "with VDN-H3; disabling it only for VDN model forwards")
+                        "with VDN-H3; disabling it only for VDN sampling runs")
 
     try:
         yield owns
@@ -86,30 +109,17 @@ def disabled_for_vdn():
                     args.disable_comfy_compiler = False
 
 
-def install_layout_guard() -> bool:
-    """Wrap VDN's own layout-wrapper factory exactly once.
+def make_outer_sample_wrapper():
+    """Return VDN's OUTER_SAMPLE wrapper, which owns the compiler switch.
 
-    ``vdn_h3.hybrid.apply_vdn`` resolves ``make_layout_wrapper`` from its module
-    globals when Apply executes, so installing after node imports is sufficient and
-    avoids modifying or wrapping any ComfyUI core callable.
+    ``vdn_h3.hybrid.apply_vdn`` registers this on the patched model only, so a
+    sampling run against an unpatched model is untouched.  Nothing in Comfy is
+    monkey-patched: this is an ordinary wrapper registration, and the switch is the
+    same config value ``--disable-comfy-compiler`` sets.
     """
-    from vdn_h3 import hybrid
+    def guarded(executor, *args, **kwargs):
+        with disabled_for_vdn():
+            return executor(*args, **kwargs)
 
-    current = hybrid.make_layout_wrapper
-    if getattr(current, "_vdn_compiler_guard_installed", False):
-        return False
-
-    @functools.wraps(current)
-    def guarded_factory(state):
-        inner = current(state)
-
-        @functools.wraps(inner)
-        def guarded(executor, *args, **kwargs):
-            with disabled_for_vdn():
-                return inner(executor, *args, **kwargs)
-
-        return guarded
-
-    guarded_factory._vdn_compiler_guard_installed = True
-    hybrid.make_layout_wrapper = guarded_factory
-    return True
+    guarded._vdn_compiler_guard = True
+    return guarded

--- a/vdn_h3/hybrid.py
+++ b/vdn_h3/hybrid.py
@@ -16,6 +16,7 @@ import comfy.quant_ops
 from comfy.ldm.modules.attention import AttentionTensorContainer, optimized_attention
 from comfy.patcher_extension import WrappersMP
 
+from vdn_h3 import compiler_guard
 from vdn_h3.runtime import RuntimeBufferOwner
 from vdn_h3.spec import resolve_branch_weights
 from vdn_h3.window import full_coverage, window_bounds
@@ -412,3 +413,9 @@ def apply_vdn(new_model, state):
         new_model.add_object_patch(key, make_vdn_forward(block.attn, state, index))
     new_model.add_wrapper_with_key(
         WrappersMP.DIFFUSION_MODEL, "vdn_h3", make_layout_wrapper(state))
+    # Must be OUTER_SAMPLE, not DIFFUSION_MODEL: core decides whether to open an
+    # AIMDO malloc graph before it runs any DIFFUSION_MODEL wrapper. See
+    # vdn_h3.compiler_guard for the exact core lines.
+    new_model.add_wrapper_with_key(
+        WrappersMP.OUTER_SAMPLE, "vdn_h3_compiler_guard",
+        compiler_guard.make_outer_sample_wrapper())


### PR DESCRIPTION
Comfy v0.34's latest Aimdo v0.5.2 update gave me some grief with another node, and it seems to have affected yours as well so I was getting errors-

The guard could never disable the malloc graph. comfy/ldm/minimax/model.py evaluates malloc_graph_enabled() and calls malloc_graph_begin() before it runs any DIFFUSION_MODEL wrapper:

    compile_allocations = comfy.model_prefetch.malloc_graph_enabled(...)
    if compile_allocations:
        out = [torch.empty_like(x[0]), torch.empty_like(x[1])]
        comfy.model_prefetch.malloc_graph_begin(self, x[0].device)
    graph_out = ...DIFFUSION_MODEL wrappers...

install_layout_guard() wrapped make_layout_wrapper, which is registered at DIFFUSION_MODEL, so the flag flipped after the decision was taken and after the graph was open. The compile went ahead regardless; the only effect was to stop the per-block prefetch_queue_pop(malloc_scope="block") recording at model.py:747 partway through a graph that stayed open and was closed normally, leaving a half-recorded allocation pattern. The two full-size empty_like staging latents stayed allocated for the whole forward as well.

Register the guard at OUTER_SAMPLE instead, which Comfy gathers in samplers.py before the sampling loop starts. malloc_graph_enabled() then returns False at the top of every forward in the run, so no graph is opened and no staging latents are allocated.

Scope is now one sampling run rather than one forward. That is the narrowest scope that is actually correct. Ownership semantics are unchanged: lazy fail-open detection, reference counting, restore in finally, and a user-supplied --disable-comfy-compiler is still never un-set.

This does not fix out-of-memory failures at long sequence lengths. Those persist and trace to first-step torch.compile cost landing at peak allocation, which is a separate problem. Reclaiming the staging latents is a real but modest benefit; guard correctness is the point of this change.

install_layout_guard() and its __init__ call site are removed; nothing in Comfy is monkey-patched and nothing in this package is either. The warning text said "disabling it only for VDN model forwards" and now says "sampling runs". Test coverage replaces the idempotent-install assertion with wrapper-level checks for set-during, restore-after, restore-on-error and user-flag-preserved. The module docstring and the README compatibility note asserted the old placement was correct and have been rewritten.