### PR TITLE
Fix Plus registry namespace and release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,38 +2,112 @@ name: Publish to Comfy registry
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - master
-    paths:
-      - "pyproject.toml"
+    inputs:
+      tag:
+        description: Published GitHub release tag to publish
+        required: true
+        type: string
+  workflow_run:
+    workflows: [release]
+    types: [completed]
 
 permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: comfy-registry-${{ inputs.tag || github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
+
 jobs:
   publish-node:
     name: Publish Custom Node to registry
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'xmarre' }}
-    env:
-      REGISTRY_ACCESS_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+    if: >-
+      github.repository_owner == 'xmarre' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      )
+
     steps:
-      - name: Check out code
+      - name: Check out workflow source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
 
-      - name: Publish Custom Node
-        if: ${{ env.REGISTRY_ACCESS_TOKEN != '' }}
-        uses: Comfy-Org/publish-node-action@0eb6cd742945443bee7f79eeddd4f732780029a1 # v1
-        with:
-          personal_access_token: ${{ env.REGISTRY_ACCESS_TOKEN }}
-
-      - name: Registry token unavailable
-        if: ${{ env.REGISTRY_ACCESS_TOKEN == '' }}
+      - name: Resolve and validate published release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.tag }}
         shell: bash
         run: |
-          echo "::warning::REGISTRY_ACCESS_TOKEN is not configured for this repository; skipping Comfy Registry publication."
+          if [[ -n "${REQUESTED_TAG}" ]]; then
+            tag="${REQUESTED_TAG}"
+          else
+            version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+            tag="v${version}"
+          fi
+
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: ${tag}" >&2
+            exit 1
+          fi
+
+          is_draft="$(gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')"
+          if [[ "${is_draft}" != "false" ]]; then
+            echo "Release ${tag} is not published." >&2
+            exit 1
+          fi
+
+          release_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq '.sha')"
+          current_main="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+          if [[ "${release_sha}" != "${current_main}" ]]; then
+            echo "Release ${tag} targets ${release_sha}, not current main ${current_main}; skipping stale registry publication."
+            echo "publish=false" >> "${GITHUB_OUTPUT}"
+            echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "publish=true" >> "${GITHUB_OUTPUT}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out released code
+        if: steps.release.outputs.publish == 'true'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Verify registry identity and package version
+        if: steps.release.outputs.publish == 'true'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        shell: bash
+        run: |
+          python - "${TAG}" <<'PY'
+          from pathlib import Path
+          import sys, tomllib
+
+          tag = sys.argv[1]
+          config = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          project = config["project"]
+          comfy = config["tool"]["comfy"]
+          version = project["version"]
+          if f"v{version}" != tag:
+              raise SystemExit(f"Release tag {tag} does not match project version v{version}.")
+          if project["name"] != "comfyui-vdn-h3-plus":
+              raise SystemExit(f"Unexpected registry package name: {project['name']!r}")
+          if comfy["PublisherId"] != "xmarre":
+              raise SystemExit(f"Unexpected PublisherId: {comfy['PublisherId']!r}")
+          PY
+
+      - name: Publish Custom Node
+        if: steps.release.outputs.publish == 'true'
+        uses: Comfy-Org/publish-node-action@0eb6cd742945443bee7f79eeddd4f732780029a1 # v1
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,10 +102,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          archive="ComfyUI-VDN-H3-v${VERSION}.zip"
+          archive="ComfyUI-VDN-H3-Plus-v${VERSION}.zip"
           git archive \
             --format=zip \
-            --prefix="ComfyUI-VDN-H3-v${VERSION}/" \
+            --prefix="ComfyUI-VDN-H3-Plus-v${VERSION}/" \
             --output="dist/${archive}" \
             HEAD
           (cd dist && sha256sum "${archive}" > SHA256SUMS)
@@ -120,9 +120,9 @@ jobs:
         shell: bash
         run: |
           gh release create "${TAG}" \
-            "dist/ComfyUI-VDN-H3-v${VERSION}.zip" \
+            "dist/ComfyUI-VDN-H3-Plus-v${VERSION}.zip" \
             dist/SHA256SUMS \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${RELEASE_SHA}" \
-            --title "ComfyUI-VDN-H3 ${TAG}" \
+            --title "ComfyUI-VDN-H3-Plus ${TAG}" \
             --notes-file CURRENT_RELEASE_NOTES.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,35 @@
+# ComfyUI-VDN-H3-Plus v1.5.4
+
+v1.5.4 is a packaging/release follow-up to v1.5.3. Runtime VDN math and provider behavior are unchanged.
+
+## Dedicated Comfy Registry identity
+
+The Plus fork now publishes under the distinct registry package name `comfyui-vdn-h3-plus` with `PublisherId = "xmarre"` and display name `ComfyUI-VDN-H3-Plus`.
+
+The previous package metadata still used upstream's `comfyui-vdn-h3` project name while changing only the publisher. That name is already associated with Saganaki22's upstream package, so the Comfy Registry correctly rejected the Plus fork publication with HTTP 403 even when a valid xmarre registry token was present.
+
+This release therefore avoids claiming or overwriting upstream's registry identity. Existing Git installs are unaffected.
+
+## Release pipeline hardening
+
+Registry publication is now tied to a successfully completed GitHub release workflow instead of publishing immediately from an arbitrary `pyproject.toml` push.
+
+Before publishing, the workflow verifies that:
+
+- the requested/current release exists and is not a draft;
+- the release tag targets current `main` rather than a stale commit;
+- the release tag exactly matches `[project].version`;
+- the registry package name is `comfyui-vdn-h3-plus`;
+- the publisher is `xmarre`.
+
+Release ZIP names, archive prefixes and GitHub release titles now consistently use the `ComfyUI-VDN-H3-Plus` fork name.
+
+## Relationship to v1.5.3
+
+All v1.5.3 functionality remains intact: rectangular softmax-provider API v3, lazy v2 square-Q compatibility, exactly-once full-domain preprocessing, INT8 ConvRot stage support/documentation, pruned AdaLN affine handling, and the production-validated Sol-H3 composition contract.
+
+The separate PR #8 audio-fidelity experiment remains unreleased and is still not a dependency of this release.
+
 # ComfyUI-VDN-H3 v1.5.3
 
 v1.5.3 adds the composable VDN softmax-provider API used by ComfyUI-Sol-H3 v0.1.0, removes the historical square-Q compatibility cost for rectangular providers, and includes the post-v1.5.2 setup/documentation fixes for INT8 ConvRot stages and pruned AdaLN affine sidecars.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "comfyui-vdn-h3"
-version = "1.5.3"
-description = "VDN-H3 hybrid attention for ComfyUI MiniMax-H3 with pre-quantized or self-built INT8 ConvRot VDN stages"
+name = "comfyui-vdn-h3-plus"
+version = "1.5.4"
+description = "VDN-H3-Plus hybrid attention for ComfyUI MiniMax-H3 with pre-quantized or self-built INT8 ConvRot VDN stages"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [
@@ -27,5 +27,5 @@ OpenVDN = "https://github.com/OpenVDN/vdn-minimax-h3"
 
 [tool.comfy]
 PublisherId = "xmarre"
-DisplayName = "ComfyUI-VDN-H3"
+DisplayName = "ComfyUI-VDN-H3-Plus"
 Icon = "https://avatars.githubusercontent.com/u/84208527"


### PR DESCRIPTION
This is a packaging/release follow-up to v1.5.3. It does not change VDN runtime math.

The Comfy Registry 403 was not a missing-token problem after the rerun: the token was present, but the Plus fork still declared `[project].name = "comfyui-vdn-h3"`, which is upstream Saganaki22's existing registry identity. The registry correctly rejected publication under xmarre.

This PR:
- moves the Plus fork to the distinct registry package ID `comfyui-vdn-h3-plus` and display name `ComfyUI-VDN-H3-Plus`;
- bumps the packaging release to v1.5.4;
- binds registry publication to the completed release workflow and validates a published, non-stale tag before publishing;
- verifies tag/version/package/publisher identity before invoking the registry action;
- brands GitHub release archives and titles consistently as `ComfyUI-VDN-H3-Plus`;
- documents that v1.5.4 is packaging-only and preserves all v1.5.3 runtime/provider behavior.

The previous v1.5.3 GitHub release remains valid as the production provider release. v1.5.4 exists to publish the divergent Plus fork under its own registry namespace and harden future release ordering.