### PR TITLE
Add owner-bound Mixed-Grid softmax epilogue capability

### DIFF
--- a/tests/test_mixed_measure_epilogue.py
+++ b/tests/test_mixed_measure_epilogue.py
@@ -1,0 +1,260 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vdn_h3.mixed_measure_epilogue import (
+    EPILOGUE_KEY,
+    EPILOGUE_RECEIPTS_KEY,
+    ExternalSoftmaxEpilogueCapability,
+    attach_external_softmax_epilogue,
+)
+
+
+class CountingProjection(torch.nn.Module):
+    def __init__(self, width):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.eye(width), requires_grad=False)
+        self.calls = 0
+
+    def forward(self, x):
+        self.calls += 1
+        return torch.nn.functional.linear(x, self.weight)
+
+
+class State:
+    def __init__(self, *, gated=True, branch=True):
+        self.name = "test"
+        self.cfg = {"enable_softmax_gate": gated}
+        self.branches = [object() if branch else None]
+        self.managed_weights = None
+        self._layout = SimpleNamespace(
+            seq_len=18,
+            video_start=6,
+            num_frames=2,
+            tokens_per_frame=6,
+        )
+        self.weight_calls = 0
+
+    @property
+    def layout(self):
+        return self._layout
+
+    def weights_on(self, index, device, dtype):
+        self.weight_calls += 1
+        assert index == 0
+        # Two heads, each receives sigmoid(0)=0.5.
+        return {
+            "softmax_gate.up.weight": torch.zeros(2, 8, device=device, dtype=dtype),
+            "softmax_gate.up.bias": torch.zeros(2, device=device, dtype=dtype),
+        }
+
+
+def options(**overrides):
+    contract = {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 18,
+        "sequence_rows": 24,
+        "video_start": 6,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 6,
+        "prefix_rows_per_frame": 12,
+    }
+    contract.update(overrides)
+    return {"vdn_h3_external_sequence_v1": contract}
+
+
+def test_capability_attaches_to_concrete_vdn_forward_once():
+    state = State()
+    projection = CountingProjection(8)
+
+    def forward(*args, **kwargs):
+        raise AssertionError("attachment must not execute the forward")
+
+    capability = attach_external_softmax_epilogue(
+        forward, state, 0, projection, heads=2, head_dim=4
+    )
+    assert getattr(forward, EPILOGUE_KEY) is capability
+    assert capability.state is state
+    assert capability.out_proj is projection
+    with pytest.raises(RuntimeError, match="already attached"):
+        attach_external_softmax_epilogue(
+            forward, state, 0, projection, heads=2, head_dim=4
+        )
+
+
+def test_nontrivial_gate_and_projection_are_applied_exactly_once():
+    state = State(gated=True, branch=True)
+    projection = CountingProjection(8)
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, projection, heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+    softmax = torch.randn(24, 2, 4)
+
+    bound = capability.prepare(x, rope, options(), 0)
+    got = bound.apply(softmax, x)
+    expected = (softmax * 0.5).reshape(24, 8)
+    torch.testing.assert_close(got, expected)
+    assert state.weight_calls == 1
+    assert projection.calls == 1
+    assert bound.gate_calls == 1
+    assert bound.projection_calls == 1
+    assert bound.completed is True
+    fields = dict(bound.receipt_fields())
+    assert fields["vdn_gate_calls"] == 1
+    assert fields["vdn_projection_calls"] == 1
+    assert fields["vdn_completed"] is True
+
+    with pytest.raises(RuntimeError, match="more than once"):
+        bound.apply(softmax, x)
+    assert projection.calls == 1
+
+
+def test_completion_receipt_is_forwarded_only_after_success():
+    state = State(gated=True, branch=True)
+    projection = CountingProjection(8)
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, projection, heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+    softmax = torch.randn(24, 2, 4)
+    receipt_sink = []
+    prepared_options = options()
+    prepared_options[EPILOGUE_RECEIPTS_KEY] = receipt_sink
+
+    bound = capability.prepare(x, rope, prepared_options, 0)
+    assert receipt_sink == []
+    bound.apply(softmax, x)
+
+    assert len(receipt_sink) == 1
+    block_index, receipt_fields = receipt_sink[0]
+    assert block_index == 0
+    fields = dict(receipt_fields)
+    assert fields["vdn_owner_generation"] == capability.owner_generation
+    assert fields["vdn_config_digest"] == capability.config_digest
+    assert fields["vdn_weight_owner_digest"] == capability.weight_owner_digest
+    assert fields["vdn_gate_expected"] is True
+    assert fields["vdn_gate_calls"] == 1
+    assert fields["vdn_projection_calls"] == 1
+    assert fields["vdn_completed"] is True
+
+    with pytest.raises(RuntimeError, match="more than once"):
+        bound.apply(softmax, x)
+    assert len(receipt_sink) == 1
+
+
+def test_failed_apply_does_not_forward_completion_receipt():
+    state = State()
+    projection = CountingProjection(8)
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, projection, heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    receipt_sink = []
+    prepared_options = options()
+    prepared_options[EPILOGUE_RECEIPTS_KEY] = receipt_sink
+    bound = capability.prepare(x, torch.zeros(1, 24, 1, 1), prepared_options, 0)
+
+    with pytest.raises(RuntimeError, match="softmax tensor"):
+        bound.apply(torch.randn(24, 8), x)
+    assert receipt_sink == []
+    assert projection.calls == 0
+
+
+def test_prepare_rejects_invalid_receipt_sink_before_binding():
+    state = State()
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, CountingProjection(8), heads=2, head_dim=4)
+    prepared_options = options()
+    prepared_options[EPILOGUE_RECEIPTS_KEY] = ()
+    with pytest.raises(RuntimeError, match="receipt sink must be a list"):
+        capability.prepare(
+            torch.randn(24, 8),
+            torch.zeros(1, 24, 1, 1),
+            prepared_options,
+            0,
+        )
+
+
+def test_branchless_block_uses_native_projection_without_gate_or_weight_load():
+    state = State(gated=True, branch=False)
+    projection = CountingProjection(8)
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, projection, heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+    softmax = torch.randn(24, 2, 4)
+
+    bound = capability.prepare(x, rope, options(), 0)
+    got = bound.apply(softmax, x)
+    torch.testing.assert_close(got, softmax.reshape(24, 8))
+    assert bound.gate_expected is False
+    assert bound.gate_calls == 0
+    assert state.weight_calls == 0
+    assert projection.calls == 1
+
+
+def test_disabled_gate_still_projects_once_and_does_not_read_gate_weights():
+    state = State(gated=False, branch=True)
+    projection = CountingProjection(8)
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, projection, heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+    softmax = torch.randn(24, 2, 4)
+
+    bound = capability.prepare(x, rope, options(), 0)
+    got = bound.apply(softmax, x)
+    torch.testing.assert_close(got, softmax.reshape(24, 8))
+    assert state.weight_calls == 0
+    assert bound.gate_calls == 0
+    assert projection.calls == 1
+
+
+def test_prepare_rejects_wrong_block_stale_geometry_and_missing_execution_lifetime():
+    state = State()
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, CountingProjection(8), heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+
+    with pytest.raises(RuntimeError, match="wrong block"):
+        capability.prepare(x, rope, options(), 1)
+    with pytest.raises(RuntimeError, match="does not match"):
+        capability.prepare(x, rope, options(sequence_rows=25), 0)
+    with pytest.raises(RuntimeError, match="explicit RoPE"):
+        capability.prepare(x, torch.zeros(1, 23, 1, 1), options(), 0)
+
+    state._layout = None
+    with pytest.raises(RuntimeError, match="outside the VDN execution lifetime"):
+        capability.prepare(x, rope, options(), 0)
+
+
+def test_prepare_rejects_mutated_branch_weight_owner_and_config():
+    x = torch.randn(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+
+    state = State()
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, CountingProjection(8), heads=2, head_dim=4)
+    state.branches[0] = object()
+    with pytest.raises(RuntimeError, match="weight ownership changed"):
+        capability.prepare(x, rope, options(), 0)
+
+    state = State()
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, CountingProjection(8), heads=2, head_dim=4)
+    state.managed_weights = object()
+    with pytest.raises(RuntimeError, match="weight ownership changed"):
+        capability.prepare(x, rope, options(), 0)
+
+    state = State()
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, CountingProjection(8), heads=2, head_dim=4)
+    state.cfg["enable_softmax_gate"] = False
+    with pytest.raises(RuntimeError, match="configuration changed"):
+        capability.prepare(x, rope, options(), 0)
+
+
+def test_apply_rejects_wrong_softmax_shape_before_projection():
+    state = State()
+    projection = CountingProjection(8)
+    capability = ExternalSoftmaxEpilogueCapability(state, 0, projection, heads=2, head_dim=4)
+    x = torch.randn(24, 8)
+    bound = capability.prepare(x, torch.zeros(1, 24, 1, 1), options(), 0)
+    with pytest.raises(RuntimeError, match="softmax tensor"):
+        bound.apply(torch.randn(24, 8), x)
+    assert projection.calls == 0

--- a/vdn_h3/hybrid.py
+++ b/vdn_h3/hybrid.py
@@ -16,6 +16,7 @@ import comfy.quant_ops
 from comfy.ldm.modules.attention import AttentionTensorContainer, optimized_attention
 from comfy.patcher_extension import WrappersMP
 
+from vdn_h3.mixed_measure_epilogue import attach_external_softmax_epilogue
 from vdn_h3.runtime import RuntimeBufferOwner
 from vdn_h3.spec import resolve_branch_weights
 from vdn_h3.window import full_coverage, window_bounds
@@ -389,6 +390,9 @@ def make_vdn_forward(attn, state, block_index):
 
     vdn_forward._vdn_forward = True
     vdn_forward._vdn_external_sequence_api = VDN_EXTERNAL_SEQUENCE_API_VERSION
+    attach_external_softmax_epilogue(
+        vdn_forward, state, block_index, out_proj, heads, head_dim
+    )
     return vdn_forward
 
 

--- a/vdn_h3/mixed_measure_epilogue.py
+++ b/vdn_h3/mixed_measure_epilogue.py
@@ -1,0 +1,249 @@
+"""VDN-owned epilogue for external Mixed-Grid sparse softmax providers.
+
+The external Mixed-Grid path keeps VDN's released learned softmax gate and the
+native attention output projection even when a companion provider computes the
+unprojected softmax result directly. This module owns only that epilogue: it
+never performs attention and never invokes VDN's geometry-dependent linear
+complement.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import uuid
+from typing import Any, Mapping
+
+import torch
+import torch.nn.functional as F
+
+EPILOGUE_KEY = "vdn_h3_external_softmax_epilogue_v1"
+EPILOGUE_RECEIPTS_KEY = "vdn_h3_external_softmax_epilogue_receipts_v1"
+EXTERNAL_SEQUENCE_KEY = "vdn_h3_external_sequence_v1"
+EXTERNAL_SEQUENCE_API = 2
+EXTERNAL_SEQUENCE_MODE = "dense_gate_no_linear"
+EXTERNAL_TOPOLOGY = "mixed_grid_low_suffix"
+
+
+def _freeze(value: Any):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(k): _freeze(v) for k, v in sorted(value.items(), key=lambda item: str(item[0]))}
+    if isinstance(value, (tuple, list)):
+        return [_freeze(v) for v in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted((_freeze(v) for v in value), key=repr)
+    return repr(value)
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(_freeze(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _config_identity(state, block_index: int, branch) -> dict[str, Any]:
+    return {
+        "name": getattr(state, "name", None),
+        "cfg": getattr(state, "cfg", None),
+        "block_index": block_index,
+        "branch_present": branch is not None,
+        "branch_type": None if branch is None else f"{type(branch).__module__}.{type(branch).__qualname__}",
+    }
+
+
+def _weight_owner(state, branch):
+    managed = getattr(state, "managed_weights", None)
+    return managed if managed is not None else branch
+
+
+def _validate_external_contract(contract, layout, rows: int, rope_freqs) -> dict[str, int]:
+    if not isinstance(contract, Mapping):
+        raise RuntimeError("VDN Mixed-Grid epilogue requires an external-sequence contract")
+    if (
+        contract.get("api") != EXTERNAL_SEQUENCE_API
+        or contract.get("mode") != EXTERNAL_SEQUENCE_MODE
+        or contract.get("topology") != EXTERNAL_TOPOLOGY
+    ):
+        raise RuntimeError("VDN Mixed-Grid epilogue received an unsupported external-sequence contract")
+    names = (
+        "native_sequence_rows",
+        "sequence_rows",
+        "video_start",
+        "temporal",
+        "prefix_t",
+        "source_rows_per_frame",
+        "prefix_rows_per_frame",
+    )
+    if any(type(contract.get(name)) is not int for name in names):
+        raise RuntimeError("VDN Mixed-Grid epilogue row counts must be integers")
+    native, actual, start, temporal, prefix_t, source_rows, prefix_rows = (contract[name] for name in names)
+    if (
+        actual != rows
+        or native != getattr(layout, "seq_len", None)
+        or start != getattr(layout, "video_start", None)
+        or temporal != getattr(layout, "num_frames", None)
+        or source_rows != getattr(layout, "tokens_per_frame", None)
+        or not 0 < prefix_t < temporal
+        or not 0 < source_rows < prefix_rows
+        or native != start + temporal * source_rows
+        or actual != start + prefix_t * prefix_rows + (temporal - prefix_t) * source_rows
+    ):
+        raise RuntimeError("VDN Mixed-Grid epilogue contract does not match the active VDN layout")
+    if rope_freqs is None or rope_freqs.ndim < 2 or int(rope_freqs.shape[1]) != rows:
+        raise RuntimeError("VDN Mixed-Grid epilogue requires explicit RoPE rows matching the mixed stream")
+    return {name: int(contract[name]) for name in names}
+
+
+@dataclass
+class BoundVDNEpilogue:
+    state: object
+    block_index: int
+    out_proj: object
+    rows: int
+    heads: int
+    head_dim: int
+    owner_generation: str
+    config_digest: str
+    weight_owner_digest: str
+    external_digest: str
+    gate_expected: bool
+    receipt_sink: list | None = None
+    projection_calls: int = 0
+    gate_calls: int = 0
+    completed: bool = False
+
+    def apply(self, softmax_out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        """Apply VDN's gate, then the original output projection, exactly once."""
+        if self.completed or self.projection_calls:
+            raise RuntimeError("VDN Mixed-Grid epilogue cannot be applied more than once")
+        if (
+            not torch.is_tensor(softmax_out)
+            or softmax_out.ndim != 3
+            or tuple(softmax_out.shape) != (self.rows, self.heads, self.head_dim)
+        ):
+            raise RuntimeError("VDN Mixed-Grid epilogue received an incompatible softmax tensor")
+        if not torch.is_tensor(x) or x.ndim != 2 or x.shape[0] != self.rows:
+            raise RuntimeError("VDN Mixed-Grid epilogue received an incompatible hidden-state tensor")
+        if softmax_out.device != x.device:
+            raise RuntimeError("VDN Mixed-Grid epilogue softmax and hidden state must share a device")
+
+        branch = self.state.branches[self.block_index]
+        if self.gate_expected:
+            if branch is None:
+                raise RuntimeError("VDN Mixed-Grid epilogue expected a learned gate but has no branch weights")
+            weights = self.state.weights_on(self.block_index, x.device, x.dtype)
+            try:
+                gate_weight = weights["softmax_gate.up.weight"]
+                gate_bias = weights["softmax_gate.up.bias"]
+            except (KeyError, TypeError) as exc:
+                raise RuntimeError("VDN Mixed-Grid epilogue is missing learned softmax-gate weights") from exc
+            gate = torch.sigmoid(F.linear(x, gate_weight, gate_bias))
+            if gate.ndim != 2 or tuple(gate.shape) != (self.rows, self.heads):
+                raise RuntimeError("VDN Mixed-Grid softmax gate returned incompatible geometry")
+            flat = (softmax_out * gate.view(self.rows, self.heads, 1).to(softmax_out.dtype)).reshape(self.rows, -1)
+            self.gate_calls += 1
+        else:
+            flat = softmax_out.reshape(self.rows, -1)
+
+        result = self.out_proj(flat.type_as(x))
+        self.projection_calls += 1
+        if not torch.is_tensor(result) or result.ndim != 2 or result.shape[0] != self.rows:
+            raise RuntimeError("VDN Mixed-Grid output projection returned incompatible geometry")
+        self.completed = True
+        if self.receipt_sink is not None:
+            self.receipt_sink.append((self.block_index, self.receipt_fields()))
+        return result
+
+    def receipt_fields(self) -> tuple[tuple[str, Any], ...]:
+        return (
+            ("vdn_owner_generation", self.owner_generation),
+            ("vdn_config_digest", self.config_digest),
+            ("vdn_weight_owner_digest", self.weight_owner_digest),
+            ("vdn_external_digest", self.external_digest),
+            ("vdn_gate_expected", self.gate_expected),
+            ("vdn_gate_calls", self.gate_calls),
+            ("vdn_projection_calls", self.projection_calls),
+            ("vdn_completed", self.completed),
+        )
+
+
+class ExternalSoftmaxEpilogueCapability:
+    """Capability attached to one VDN-patched MiniMax-H3 attention owner."""
+
+    api = 1
+
+    def __init__(self, state, block_index: int, out_proj, heads: int, head_dim: int):
+        if type(block_index) is not int or block_index < 0:
+            raise ValueError("VDN epilogue block index must be a nonnegative integer")
+        self.state = state
+        self.block_index = block_index
+        self.out_proj = out_proj
+        self.heads = int(heads)
+        self.head_dim = int(head_dim)
+        self.owner_generation = f"vdn-epilogue-{uuid.uuid4().hex}"
+        branch = state.branches[block_index]
+        self.branch_owner = branch
+        self.weight_owner = _weight_owner(state, branch)
+        self.config_digest = _digest(_config_identity(state, block_index, branch))
+        self.weight_owner_digest = _digest({
+            "epilogue_owner_generation": self.owner_generation,
+            "owner_type": None if self.weight_owner is None else f"{type(self.weight_owner).__module__}.{type(self.weight_owner).__qualname__}",
+            "block_index": block_index,
+            "branch_present": branch is not None,
+        })
+
+    def prepare(self, x, rope_freqs, options, block_index):
+        if type(block_index) is not int or block_index != self.block_index:
+            raise RuntimeError("VDN Mixed-Grid epilogue was requested for the wrong block owner")
+        if not torch.is_tensor(x) or x.ndim != 2:
+            raise RuntimeError("VDN Mixed-Grid epilogue requires [T,D] hidden states")
+        layout = self.state.layout
+        if layout is None:
+            raise RuntimeError("VDN Mixed-Grid epilogue called outside the VDN execution lifetime")
+        branch = self.state.branches[block_index]
+        if branch is not self.branch_owner or _weight_owner(self.state, branch) is not self.weight_owner:
+            raise RuntimeError("VDN Mixed-Grid epilogue weight ownership changed after capability attachment")
+        if _digest(_config_identity(self.state, block_index, branch)) != self.config_digest:
+            raise RuntimeError("VDN Mixed-Grid epilogue configuration changed after capability attachment")
+        option_map = options or {}
+        receipt_sink = option_map.get(EPILOGUE_RECEIPTS_KEY)
+        if receipt_sink is not None and not isinstance(receipt_sink, list):
+            raise RuntimeError("VDN Mixed-Grid epilogue receipt sink must be a list")
+        contract = option_map.get(EXTERNAL_SEQUENCE_KEY)
+        normalized = _validate_external_contract(contract, layout, int(x.shape[0]), rope_freqs)
+        gate_expected = bool(branch is not None and self.state.cfg.get("enable_softmax_gate", True))
+        return BoundVDNEpilogue(
+            state=self.state,
+            block_index=block_index,
+            out_proj=self.out_proj,
+            rows=int(x.shape[0]),
+            heads=self.heads,
+            head_dim=self.head_dim,
+            owner_generation=self.owner_generation,
+            config_digest=self.config_digest,
+            weight_owner_digest=self.weight_owner_digest,
+            external_digest=_digest(normalized),
+            gate_expected=gate_expected,
+            receipt_sink=receipt_sink,
+        )
+
+
+def attach_external_softmax_epilogue(forward, state, block_index: int, out_proj, heads: int, head_dim: int):
+    """Attach one explicit owner-bound Mixed-Grid epilogue to a VDN forward."""
+    if not callable(forward):
+        raise TypeError("VDN Mixed-Grid epilogue owner must be callable")
+    if hasattr(forward, EPILOGUE_KEY):
+        raise RuntimeError("VDN Mixed-Grid epilogue capability is already attached")
+    capability = ExternalSoftmaxEpilogueCapability(state, block_index, out_proj, heads, head_dim)
+    setattr(forward, EPILOGUE_KEY, capability)
+    return capability
+
+
+__all__ = [
+    "EPILOGUE_KEY",
+    "EPILOGUE_RECEIPTS_KEY",
+    "BoundVDNEpilogue",
+    "ExternalSoftmaxEpilogueCapability",
+    "attach_external_softmax_epilogue",
+]


### PR DESCRIPTION
Structural companion for the Progressive Mixed-Grid attention-measure stack.

This PR publishes one explicit VDN-owned epilogue capability on each patched MiniMax-H3 attention forward for API-2 `dense_gate_no_linear` Mixed-Grid execution. A compatible external attention provider can bind that concrete owner and preserve VDN's released softmax epilogue without importing VDN internals.

The bound epilogue:
- validates the active VDN execution lifetime, exact block owner, API-2 Mixed-Grid geometry and matching RoPE rows;
- applies the released learned sigmoid softmax gate when configured;
- invokes the native attention output projection exactly once;
- never invokes the geometry-dependent VDN linear complement on the API-2 Mixed-Grid path;
- rejects duplicate/stale ownership and double application;
- records owner/config/weight/external-contract identity plus gate/projection cardinality and completion state;
- appends the completion receipt only after successful projection, so downstream Spectrum history eligibility proves completed VDN consumption rather than advertised capability.

Branchless/gate-disabled execution does not load learned gate weights. API-2 geometry alone does not prove VDN presence; the concrete `_vdn_forward` owner marker remains the ownership boundary.

CPU oracle tests cover a nontrivial gate, projection cardinality, branchless blocks, disabled gates without weight loads, concrete forward attachment, stale geometry/RoPE/lifetime rejection, incompatible softmax shape, duplicate application, and completion-receipt forwarding.

CI run `34555404823` on the consolidated one-commit head completed successfully. This is structural/CPU evidence only.

This PR does not itself activate weighted Mixed-Grid attention. Activation requires the matching Flow request, ComfyUI core capability/binding, provider-side key-bias support, and Spectrum history/receipt integration. Those companions now exist structurally, but CUDA numerical behavior, decoded-media parity, production schedule preservation, and performance remain unvalidated.

Required production gates still include:
- real weighted CUDA execution with VDN ownership;
- proof that gate and `out_proj` execute exactly once on the production sparse route;
- owner/config/layout-matched receipt consumption by Spectrum;
- applicable `18 logical / 14 actual / 4 forecast` behavior with no correction NFE;
- decoded audio/video and performance validation.

Architecture: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/29
Flow implementation: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/30
Core companion: https://github.com/Comfy-Org/ComfyUI/pull/16239
Spectrum companion: https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/pull/110